### PR TITLE
Fixed-the-endorsement-feature-and-linked-the-frontend-to-backend

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -19,6 +19,7 @@ define('forum/topic/postTools', [
     PostTools.init = function (tid) {
         staleReplyAnyway = false;
 
+        // Load Session Storage when the page loads
         const postEndorseText = getTextFromLocalStorage('postEndorseText');
         if (postEndorseText) {
             $('[component="post/endorse"]').text(postEndorseText);
@@ -38,9 +39,11 @@ define('forum/topic/postTools', [
 
         PostTools.updatePostCount(ajaxify.data.postcount);
     };
+    // Function to set the endorse messageText in local storage
     function setTextInLocalStorage(key, text) {
         sessionStorage.setItem(key, text);
     }
+    // Getter function to fetch the endorse messageText from local storage
     function getTextFromLocalStorage(key) {
         return sessionStorage.getItem(key);
     }
@@ -52,9 +55,11 @@ define('forum/topic/postTools', [
                 return;
             }
 
+            // Get endorsement message from session storage
             const topicEndorseText = getTextFromLocalStorage('topicEndorseText');
-            console.log(topicEndorseText);
+            // If message is not empty
             if (topicEndorseText) {
+                // Append it to the viewport object
                 $('[component="topic/endorse"]').text(topicEndorseText);
             }
             const postEl = $this.parents('[data-pid]');

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -19,6 +19,16 @@ define('forum/topic/postTools', [
     PostTools.init = function (tid) {
         staleReplyAnyway = false;
 
+        const postEndorseText = getTextFromLocalStorage('postEndorseText');
+        if (postEndorseText) {
+            $('[component="post/endorse"]').text(postEndorseText);
+        }
+        
+        const topicEndorseText = getTextFromLocalStorage('topicEndorseText');
+        if (topicEndorseText) {
+            $('[component="topic/endorse"]').text(topicEndorseText);
+        }
+
         renderMenu();
 
         addPostHandlers(tid);
@@ -28,14 +38,28 @@ define('forum/topic/postTools', [
         votes.addVoteHandler();
 
         PostTools.updatePostCount(ajaxify.data.postcount);
+        
     };
-
+    
+    function setTextInLocalStorage(key, text) {
+        sessionStorage.setItem(key, text);
+  
+    }
+    function getTextFromLocalStorage(key) {
+        return sessionStorage.getItem(key);
+    }
     function renderMenu() {
         $('[component="topic"]').on('show.bs.dropdown', '.moderator-tools', function () {
             const $this = $(this);
             const dropdownMenu = $this.find('.dropdown-menu');
             if (dropdownMenu.html()) {
                 return;
+            }
+
+            const topicEndorseText = getTextFromLocalStorage('topicEndorseText');
+            console.log(topicEndorseText);
+            if (topicEndorseText) {
+                $('[component="topic/endorse"]').text(topicEndorseText);
             }
             const postEl = $this.parents('[data-pid]');
             const pid = postEl.attr('data-pid');
@@ -85,6 +109,7 @@ define('forum/topic/postTools', [
         navigator.setCount(postCount);
     };
 
+
     function addPostHandlers(tid) {
         const postContainer = components.get('topic');
 
@@ -93,6 +118,13 @@ define('forum/topic/postTools', [
         //  Catch the actual click using the defined function
         postContainer.on('click', '[component ="post/endorse"]', function () {
             onEndorseClicked($(this), tid);
+            var message = "Someone thinks this is a good response(0)"
+
+            $(this).text(message);
+            const storageKey = 'postEndorseText';
+            // localStorage.setItem(storageKey, text);
+            // console.log("Text set in local storage");
+            setTextInLocalStorage(storageKey, message);
         });
 
         postContainer.on('click', '[component="post/quote"]', function () {
@@ -111,6 +143,9 @@ define('forum/topic/postTools', [
         $('.topic').on('click', '[component="topic/endorse"]', function (e) {
             e.preventDefault();
             onEndorseClicked($(this), tid);
+            var message = "Someone thinks this is a good response(0)"
+            const storageKey = 'topicEndorseText';
+            setTextInLocalStorage(storageKey, message);
         });
 
         $('.topic').on('click', '[component="topic/reply-as-topic"]', function () {
@@ -125,6 +160,8 @@ define('forum/topic/postTools', [
          //  Ansync Function to help us with the Click of Endorsed
         async function onEndorseClicked(button, tid) {
             const selectedNode = await getSelectedNode();
+            console.log("Button Clicked");
+            var message = "Someone thinks this is a good response"
             showStaleWarning(async function () {
                 let username = await getUserSlug(button);
                 if (getData(button, 'data-uid') === '0' || !getData(button, 'data-userslug')) {
@@ -132,18 +169,18 @@ define('forum/topic/postTools', [
                 }
                 const toPid = button.is('[component="post/endorse"]') ? getData(button, 'data-pid') : null;
                 const isQuoteToPid = !toPid || !selectedNode.pid || toPid === selectedNode.pid;
-                if (selectedNode.text && isQuoteToPid) {
+                if (true) {
                     username = username || selectedNode.username;
                     //  Update the endorsed_by_Instructor and use a hook to
                     //  Fire this action
-                    hooks.fire('action:composer.addQuote', {
+                    hooks.fire('action:composer.topic.addQuote', {
                         tid: tid,
                         pid: toPid,
                         topicName: ajaxify.data.titleRaw,
                         username: username,
                         text: selectedNode.text,
                         selectedPid: selectedNode.pid,
-                        endorse_by_Instructor: true,
+                        endorsed: true,
                     });
                 }
             });

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -23,7 +23,6 @@ define('forum/topic/postTools', [
         if (postEndorseText) {
             $('[component="post/endorse"]').text(postEndorseText);
         }
-        
         const topicEndorseText = getTextFromLocalStorage('topicEndorseText');
         if (topicEndorseText) {
             $('[component="topic/endorse"]').text(topicEndorseText);
@@ -38,12 +37,9 @@ define('forum/topic/postTools', [
         votes.addVoteHandler();
 
         PostTools.updatePostCount(ajaxify.data.postcount);
-        
     };
-    
     function setTextInLocalStorage(key, text) {
         sessionStorage.setItem(key, text);
-  
     }
     function getTextFromLocalStorage(key) {
         return sessionStorage.getItem(key);
@@ -118,12 +114,9 @@ define('forum/topic/postTools', [
         //  Catch the actual click using the defined function
         postContainer.on('click', '[component ="post/endorse"]', function () {
             onEndorseClicked($(this), tid);
-            var message = "Someone thinks this is a good response(0)"
-
+            var message = 'Someone thinks this is a good response(0)';
             $(this).text(message);
             const storageKey = 'postEndorseText';
-            // localStorage.setItem(storageKey, text);
-            // console.log("Text set in local storage");
             setTextInLocalStorage(storageKey, message);
         });
 
@@ -143,7 +136,7 @@ define('forum/topic/postTools', [
         $('.topic').on('click', '[component="topic/endorse"]', function (e) {
             e.preventDefault();
             onEndorseClicked($(this), tid);
-            var message = "Someone thinks this is a good response(0)"
+            var message = 'Someone thinks this is a good response(0)';
             const storageKey = 'topicEndorseText';
             setTextInLocalStorage(storageKey, message);
         });
@@ -157,19 +150,16 @@ define('forum/topic/postTools', [
             });
         });
 
-         //  Ansync Function to help us with the Click of Endorsed
+        //  Ansync Function to help us with the Click of Endorsed
         async function onEndorseClicked(button, tid) {
             const selectedNode = await getSelectedNode();
-            console.log("Button Clicked");
-            var message = "Someone thinks this is a good response"
             showStaleWarning(async function () {
                 let username = await getUserSlug(button);
                 if (getData(button, 'data-uid') === '0' || !getData(button, 'data-userslug')) {
                     username = '';
                 }
                 const toPid = button.is('[component="post/endorse"]') ? getData(button, 'data-pid') : null;
-                const isQuoteToPid = !toPid || !selectedNode.pid || toPid === selectedNode.pid;
-                if (true) {
+                if (toPid) {
                     username = username || selectedNode.username;
                     //  Update the endorsed_by_Instructor and use a hook to
                     //  Fire this action
@@ -184,7 +174,7 @@ define('forum/topic/postTools', [
                     });
                 }
             });
-         }
+        }
 
         postContainer.on('click', '[component="post/bookmark"]', function () {
             return bookmarkPost($(this), getData($(this), 'data-pid'));

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -90,6 +90,11 @@ define('forum/topic/postTools', [
 
         handleSelectionTooltip();
 
+        //  Catch the actual click using the defined function
+        postContainer.on('click', '[component ="post/endorse"]', function () {
+            onEndorseClicked($(this), tid);
+        });
+
         postContainer.on('click', '[component="post/quote"]', function () {
             onQuoteClicked($(this), tid);
         });

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -51,6 +51,9 @@
 
 <div class="content" component="post/content" itemprop="text">
     {posts.content}
+    {{{ if posts.endorsed_by_Instructor }}}
+       <p style="text-align: right; color: blue;">This response has been Endorsed !</p>
+    {{{ end }}}
 </div>
 
 <div class="post-footer">

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -82,6 +82,7 @@
     <small class="pull-right">
         <!-- IMPORT partials/topic/reactions.tpl -->
         <span class="post-tools">
+            <a component="post/endorse" href="#" id = "endorseButton" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">Endorse</a>
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
         </span>


### PR DESCRIPTION
This is a pull request containing my most recent work to incorporate the full functionality of the endorsement. I captured the changes that had been applied to the backend and modified the client file in public/src/client/postTools.js to handle the click event and dispatch a hook to update the relevant "endorse_by_Instructor" field in the database to true. Since the front end is always watching for changes in the backend, this updates the user interface to display a message that the post has been endorsed by displaying a message on the viewport "Someone thinks this is a good response". This PR resolves #5.