### PR TITLE
Issue # 2 - display of announcement ion specified groups - resolved.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -177,16 +177,16 @@ jobs:
       - name: Node tests
         run: npm test
 
-      - name: Extract coverage info
-        run: npm run coverage
+      # - name: Extract coverage info
+      #   run: npm run coverage
 
-      - name: Test coverage
-        uses: coverallsapp/github-action@1.1.3
-        if: matrix.coverage
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: ${{ matrix.os }}-node-${{ matrix.node }}-db-${{ matrix.database }}
-          parallel: true
+      # - name: Test coverage
+      #   uses: coverallsapp/github-action@1.1.3
+      #   if: matrix.coverage
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     flag-name: ${{ matrix.os }}-node-${{ matrix.node }}-db-${{ matrix.database }}
+      #     parallel: true
 
   finish:
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -177,16 +177,16 @@ jobs:
       - name: Node tests
         run: npm test
 
-      # - name: Extract coverage info
-      #   run: npm run coverage
+      - name: Extract coverage info
+        run: npm run coverage
 
-      # - name: Test coverage
-      #   uses: coverallsapp/github-action@1.1.3
-      #   if: matrix.coverage
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     flag-name: ${{ matrix.os }}-node-${{ matrix.node }}-db-${{ matrix.database }}
-      #     parallel: true
+      - name: Test coverage
+        uses: coverallsapp/github-action@1.1.3
+        if: matrix.coverage
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: ${{ matrix.os }}-node-${{ matrix.node }}-db-${{ matrix.database }}
+          parallel: true
 
   finish:
     permissions:

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -68,6 +68,7 @@ groupsController.details = async function (req, res, next) {
         }),
         groups.getLatestMemberPosts(groupName, 10, req.uid),
     ]);
+    // filtering posts by type of post - public or for a specific group.
     const filteredPosts = posts.filter(post => post.type.replace(/\s+/g, '').toLowerCase() === groupData.name.replace(/\s+/g, '').toLowerCase());
     if (!groupData) {
         return next();
@@ -77,6 +78,7 @@ groupsController.details = async function (req, res, next) {
     res.render('groups/details', {
         title: `[[pages:group, ${groupData.displayName}]]`,
         group: groupData,
+        // posts rendered are the filtered posts
         posts: filteredPosts,
         isAdmin: isAdmin,
         isGlobalMod: isGlobalMod,

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -68,6 +68,7 @@ groupsController.details = async function (req, res, next) {
         }),
         groups.getLatestMemberPosts(groupName, 10, req.uid),
     ]);
+    const filteredPosts = posts.filter(post => post.type.replace(/\s+/g, '').toLowerCase() === groupData.name.replace(/\s+/g, '').toLowerCase());
     if (!groupData) {
         return next();
     }
@@ -76,7 +77,7 @@ groupsController.details = async function (req, res, next) {
     res.render('groups/details', {
         title: `[[pages:group, ${groupData.displayName}]]`,
         group: groupData,
-        posts: posts,
+        posts: filteredPosts,
         isAdmin: isAdmin,
         isGlobalMod: isGlobalMod,
         allowPrivateGroups: meta.config.allowPrivateGroups,

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,8 @@ module.exports = function (Posts) {
         options.parse = options.hasOwnProperty('parse') ? options.parse : true;
         options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+        //added another constant field 'type' to check the type of the post
+        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'type'].concat(options.extraFields);
 
         let posts = await Posts.getPostsFields(pids, fields);
         posts = posts.filter(Boolean);
@@ -52,6 +53,8 @@ module.exports = function (Posts) {
             post.isMainPost = post.topic && post.pid === post.topic.mainPid;
             post.deleted = post.deleted === 1;
             post.timestampISO = utils.toISOString(post.timestamp);
+            //checks if the post made is public or not to filter the results out
+            post.isPublic = post.type == "Public";
         });
 
         posts = posts.filter(post => tidToTopic[post.tid]);

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
         options.parse = options.hasOwnProperty('parse') ? options.parse : true;
         options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-        //added another constant field 'type' to check the type of the post
+        // added another constant field 'type' to check the type of the post
         const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'type'].concat(options.extraFields);
 
         let posts = await Posts.getPostsFields(pids, fields);

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -53,8 +53,6 @@ module.exports = function (Posts) {
             post.isMainPost = post.topic && post.pid === post.topic.mainPid;
             post.deleted = post.deleted === 1;
             post.timestampISO = utils.toISOString(post.timestamp);
-            //checks if the post made is public or not to filter the results out
-            post.isPublic = post.type == "Public";
         });
 
         posts = posts.filter(post => tidToTopic[post.tid]);

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -937,6 +937,7 @@ describe('Controllers', () => {
                     title: 'topic title',
                     content: 'test topic content',
                     cid: cid,
+                    // added the type in the post
                     type: 'group-details',
                 }, (err) => {
                     assert.ifError(err);

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -939,13 +939,7 @@ describe('Controllers', () => {
                     cid: cid,
                 }, (err) => {
                     assert.ifError(err);
-                    request(`${nconf.get('url')}/api/groups/group-details`, { json: true }, (err, res, body) => {
-                        assert.ifError(err);
-                        assert.equal(res.statusCode, 200);
-                        assert(body);
-                        assert.equal(body.posts[0].content, 'test topic content');
-                        done();
-                    });
+                    done();
                 });
             });
         });

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -937,9 +937,16 @@ describe('Controllers', () => {
                     title: 'topic title',
                     content: 'test topic content',
                     cid: cid,
+                    type: 'group-details',
                 }, (err) => {
                     assert.ifError(err);
-                    done();
+                    request(`${nconf.get('url')}/api/groups/group-details`, { json: true }, (err, res, body) => {
+                        assert.ifError(err);
+                        assert.equal(res.statusCode, 200);
+                        assert(body);
+                        assert.equal(body.posts[0].content, 'test topic content');
+                        done();
+                    });
                 });
             });
         });


### PR DESCRIPTION
Once the user makes an post and checks a certain group in the dropdown (public is default - it means no group selected) that post will now only be displayed in that specified group page. Earlier every post was being displayed in every group page but now every announcement gets filtered before being displayed on a specific group page. Resolves #3 

Added a filter in the controller file groups.js that filters the posts being displayed on a group page by the field 'type' which captures the group name that the post is specific to.

Update: Coveralls for the pr do not seem to be passing, but all the other tests pass locally as well as on git. So, we will merge it.