### PR TITLE
Fixing anonymous posts details - icons and displayname on group pages

### DIFF
--- a/public/src/modules/helpers.common.js
+++ b/public/src/modules/helpers.common.js
@@ -23,7 +23,6 @@ module.exports = function (utils, Benchpress, relative_path) {
         renderDigestAvatar,
         userAgentIcons,
         buildAvatar,
-        anonymousIcon,
         register,
         __escape: identity,
     };
@@ -341,11 +340,6 @@ module.exports = function (utils, Benchpress, relative_path) {
 
         styles.push('background-color: ' + userObj['icon:bgColor'] + ';');
         return '<span ' + attributes.join(' ') + ' style="' + styles.join(' ') + '">' + userObj['icon:text'] + '</span>';
-    }
-
-    // function for anonymous icon to display topic-lists, displays nothing for profile icon
-    function anonymousIcon() {
-        return;
     }
 
     function register() {

--- a/public/src/modules/helpers.common.js
+++ b/public/src/modules/helpers.common.js
@@ -343,11 +343,9 @@ module.exports = function (utils, Benchpress, relative_path) {
         return '<span ' + attributes.join(' ') + ' style="' + styles.join(' ') + '">' + userObj['icon:text'] + '</span>';
     }
 
-    // function for anonymous icon to display topic-lists
+    // function for anonymous icon to display topic-lists, displays nothing for profile icon
     function anonymousIcon() {
-        const styles = [];
-        styles.push('color: #100100; text-align: center; line-height: 50px; width: 50px; height: 50px; border-radius: 50%;');
-        return '<span style="' + styles.join(' ') + '"><i class="fa fa-user" style="font-size: 40px;"></i></span>';
+        return;
     }
 
     function register() {

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -21,7 +21,7 @@ module.exports = function (Posts) {
         options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
         // added another constant field 'type' to check the type of the post
-        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'type'].concat(options.extraFields);
+        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'type', 'isAnonymous'].concat(options.extraFields);
 
         let posts = await Posts.getPostsFields(pids, fields);
         posts = posts.filter(Boolean);
@@ -53,6 +53,7 @@ module.exports = function (Posts) {
             post.isMainPost = post.topic && post.pid === post.topic.mainPid;
             post.deleted = post.deleted === 1;
             post.timestampISO = utils.toISOString(post.timestamp);
+            post.isAnonymous = post.isAnonymous === "true";
         });
 
         posts = posts.filter(post => tidToTopic[post.tid]);

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,8 +20,9 @@ module.exports = function (Posts) {
         options.parse = options.hasOwnProperty('parse') ? options.parse : true;
         options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-        // added another constant field 'type' to check the type of the post and isAnonymous to trach anonymity of the post
-        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'type', 'isAnonymous'].concat(options.extraFields);
+        // added field 'type' to check the type of the post and isAnonymous to track anonymity of the post
+        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted',
+            'upvotes', 'downvotes', 'replies', 'handle', 'type', 'isAnonymous'].concat(options.extraFields);
 
         let posts = await Posts.getPostsFields(pids, fields);
         posts = posts.filter(Boolean);
@@ -54,7 +55,7 @@ module.exports = function (Posts) {
             post.deleted = post.deleted === 1;
             post.timestampISO = utils.toISOString(post.timestamp);
             // tracking if the post is anonymous
-            post.isAnonymous = post.isAnonymous === "true";
+            post.isAnonymous = post.isAnonymous === 'true';
         });
 
         posts = posts.filter(post => tidToTopic[post.tid]);

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
         options.parse = options.hasOwnProperty('parse') ? options.parse : true;
         options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-        // added another constant field 'type' to check the type of the post
+        // added another constant field 'type' to check the type of the post and isAnonymous to trach anonymity of the post
         const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'type', 'isAnonymous'].concat(options.extraFields);
 
         let posts = await Posts.getPostsFields(pids, fields);
@@ -53,6 +53,7 @@ module.exports = function (Posts) {
             post.isMainPost = post.topic && post.pid === post.topic.mainPid;
             post.deleted = post.deleted === 1;
             post.timestampISO = utils.toISOString(post.timestamp);
+            // tracking if the post is anonymous
             post.isAnonymous = post.isAnonymous === "true";
         });
 

--- a/themes/nodebb-theme-persona/templates/partials/posts_list_item.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/posts_list_item.tpl
@@ -21,12 +21,21 @@
         {{{ end }}}
 
         <div class="post-info">
+            {{{if !../isAnonymous}}}
             <a href="{config.relative_path}/user/{../user.userslug}">{buildAvatar(../user, "md", true, "user-img not-responsive")}</a>
-
             <div class="post-author">
                 <a href="{config.relative_path}/user/{../user.userslug}">{../user.displayname}</a><br />
                 <span class="timeago" title="{../timestampISO}"></span>
             </div>
+            {{{ end }}}
+
+            {{{if ../isAnonymous}}}
+            <div class="post-author">
+                <a>Posted anonymously..</a><br />
+                <span class="timeago" title="{../timestampISO}"></span>
+            </div>
+            {{{ end }}}
+
         </div>
     </div>
 </li>

--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -9,9 +9,7 @@
 
         <div class="col-md-6 col-sm-9 col-xs-10 content">
             <div class="avatar pull-left">
-                <!-- IF topics.isAnonymous -->
-                    {anonymousIcon()}
-                <!-- ELSE -->
+                <!-- IF !topics.isAnonymous -->
                     <!-- IF showSelect -->
                     <div class="select" component="topic/select">
                         {{{ if ./thumbs.length }}}
@@ -22,7 +20,7 @@
                         <i class="fa fa-check"></i>
                     </div>
                     <!-- ENDIF showSelect -->
-                <!-- ENDIF topics.isAnonymous-->
+                <!-- ENDIF !topics.isAnonymous-->
 
                 <!-- IF !showSelect -->
                     <!-- IF !topics.isAnonymous -->
@@ -31,11 +29,9 @@
                     {{{ if ./thumbs.length }}}
                     <img src="{./thumbs.0.url}" class="user-img not-responsive" />
                     {{{ else }}}
-                    <!-- IF topics.isAnonymous -->
-                        {anonymousIcon()}
-                    <!-- ELSE -->
+                    <!-- IF !topics.isAnonymous -->
                         {buildAvatar(../user, "46", true, "not-responsive")}
-                    <!-- ENDIF topics.isAnonymous-->
+                    <!-- ENDIF !topics.isAnonymous-->
                     {{{ end }}}
                 </a>
                 <!-- ENDIF !showSelect -->

--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -9,7 +9,9 @@
 
         <div class="col-md-6 col-sm-9 col-xs-10 content">
             <div class="avatar pull-left">
-                <!-- IF !topics.isAnonymous -->
+                <!-- IF topics.isAnonymous -->
+                    {anonymousIcon()}
+                <!-- ELSE -->
                     <!-- IF showSelect -->
                     <div class="select" component="topic/select">
                         {{{ if ./thumbs.length }}}
@@ -20,7 +22,7 @@
                         <i class="fa fa-check"></i>
                     </div>
                     <!-- ENDIF showSelect -->
-                <!-- ENDIF !topics.isAnonymous-->
+                <!-- ENDIF topics.isAnonymous-->
 
                 <!-- IF !showSelect -->
                     <!-- IF !topics.isAnonymous -->
@@ -29,9 +31,11 @@
                     {{{ if ./thumbs.length }}}
                     <img src="{./thumbs.0.url}" class="user-img not-responsive" />
                     {{{ else }}}
-                    <!-- IF !topics.isAnonymous -->
+                    <!-- IF topics.isAnonymous -->
+                        {anonymousIcon()}
+                    <!-- ELSE -->
                         {buildAvatar(../user, "46", true, "not-responsive")}
-                    <!-- ENDIF !topics.isAnonymous-->
+                    <!-- ENDIF topics.isAnonymous-->
                     {{{ end }}}
                 </a>
                 <!-- ENDIF !showSelect -->
@@ -66,7 +70,11 @@
                 </span>
                 {{{ end }}}
 
-                <small class="hidden-xs"><span class="timeago" title="{topics.timestampISO}"></span> &bull; <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">{topics.user.displayname}</a></small>
+                <!-- IF !topics.isAnonymous -->
+                    <small class="hidden-xs"><span class="timeago" title="{topics.timestampISO}"></span> &bull; <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">{topics.user.displayname}</a></small>
+                <!-- ELSE -->
+                    <small class="hidden-xs"><span class="timeago" title="{topics.timestampISO}"></span> &bull; <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">anon</a></small>
+                <!-- ENDIF !topics.isAnonymous -->
                 <small class="visible-xs-inline">
                     <!-- IF topics.teaser.timestamp -->
                     <span class="timeago" title="{topics.teaser.timestampISO}"></span>


### PR DESCRIPTION
This pull request was made to fix tiny bugs in the issue of displaying anonymous icon and anonymous display name on group pages. Earlier, when topics were displayed when we click on a category, the default user icon was being displayed twice, so I fixed it display no profile icon at all for anonymous posts. Also, the display name for the topics being displayed still showed the username of the user who posted anonymously, so we updated the topics_list.tpl file to make the display name of the anonymous user as "anon" for topics as well. 
The second set of changes was to hide the profile icon and the username of anonymous posts on group pages. Earlier, the anonymous feature only worked on post displays in categories, but now if we click on a group page and see the posts being displayed there, the anonymity of anonymous posters is maintained on group pages as well. Main changes made in post_list_item.tpl where post.isAnonymous was rendered and profile icon and display name was changed accordingly.