### PR TITLE
Setup StandardJS tool in the project as static analysis tool

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -171,6 +171,7 @@
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
         "smtp-server": "3.11.0",
+        "standard": "^17.1.0",
         "typescript": "^4.9.4"
     },
     "resolutions": {

--- a/src/admin/search.js
+++ b/src/admin/search.js
@@ -11,14 +11,14 @@ const { Translator } = require('../translator');
 
 function filterDirectories(directories) {
     return directories.map(
-        // get the relative path
-        // convert dir to use forward slashes
+    // get the relative path
+    // convert dir to use forward slashes
         dir => dir.replace(/^.*(admin.*?).tpl$/, '$1').split(path.sep).join('/')
     ).filter(
-        // exclude .js files
-        // exclude partials
-        // only include subpaths
-        // exclude category.tpl, group.tpl, category-analytics.tpl
+    // exclude .js files
+    // exclude partials
+    // only include subpaths
+    // exclude category.tpl, group.tpl, category-analytics.tpl
         dir => (
             !dir.endsWith('.js') &&
             !dir.includes('/partials/') &&
@@ -68,9 +68,9 @@ async function initFallback(namespace) {
     translations += `\n${title}`;
 
     return {
-        namespace: namespace,
-        translations: translations,
-        title: title,
+        namespace,
+        translations,
+        title,
     };
 }
 
@@ -104,19 +104,21 @@ async function buildNamespace(language, namespace) {
         title = title.match(/admin\/(.+?)\/(.+?)$/);
         title = `[[admin/menu:section-${
             title[1] === 'development' ? 'advanced' : title[1]
-        }]]${title[2] ? (` > [[admin/menu:${
-            title[1]}/${title[2]}]]`) : ''}`;
+        }]]${title[2] ?
+            (` > [[admin/menu:${
+                title[1]}/${title[2]}]]`) :
+            ''}`;
 
         title = await translator.translate(title);
         return {
-            namespace: namespace,
+            namespace,
             translations: `${str}\n${title}`,
-            title: title,
+            title,
         };
     } catch (err) {
         winston.error(err.stack);
         return {
-            namespace: namespace,
+            namespace,
             translations: '',
         };
     }

--- a/src/admin/versions.js
+++ b/src/admin/versions.js
@@ -21,7 +21,7 @@ function getLatestVersion(callback) {
 
     request('https://api.github.com/repos/NodeBB/NodeBB/releases/latest', {
         json: true,
-        headers: headers,
+        headers,
         timeout: 2000,
     }, (err, res, latestRelease) => {
         if (err) {

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -42,13 +42,13 @@ Analytics.init = async function () {
         ttl: 0,
     });
 
-    new cronJob('*/10 * * * * *', (async () => {
+    new cronJob('*/10 * * * * *', async () => {
         publishLocalAnalytics();
         if (runJobs) {
             await sleep(2000);
             await Analytics.writeData();
         }
-    }), null, true);
+    }, null, true);
 
     if (runJobs) {
         pubsub.on('analytics:publish', (data) => {
@@ -59,7 +59,7 @@ Analytics.init = async function () {
 
 function publishLocalAnalytics() {
     pubsub.publish('analytics:publish', {
-        local: local,
+        local,
     });
     local = _.cloneDeep(empty);
 }
@@ -78,7 +78,7 @@ function incrementProperties(obj1, obj2) {
 Analytics.increment = function (keys, callback) {
     keys = Array.isArray(keys) ? keys : [keys];
 
-    plugins.hooks.fire('action:analytics.increment', { keys: keys });
+    plugins.hooks.fire('action:analytics.increment', { keys });
 
     keys.forEach((key) => {
         local.counters[key] = local.counters[key] || 0;
@@ -104,7 +104,7 @@ Analytics.pageView = async function (payload) {
     }
 
     if (payload.ip) {
-        // Retrieve hash or calculate if not present
+    // Retrieve hash or calculate if not present
         let hash = ipCache.get(payload.ip + secret);
         if (!hash) {
             hash = crypto.createHash('sha1').update(payload.ip + secret).digest('hex');
@@ -244,7 +244,7 @@ Analytics.getDailyStatsForSet = async function (set, day, numDays) {
     day.setHours(0, 0, 0, 0);
 
     while (numDays > 0) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         const dayData = await Analytics.getHourlyStatsForSet(
             set,
             day.getTime() - (1000 * 60 * 60 * 24 * (numDays - 1)),

--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -41,7 +41,7 @@ categoriesAPI.delete = async function (caller, data) {
         uid: caller.uid,
         ip: caller.ip,
         cid: data.cid,
-        name: name,
+        name,
     });
 };
 

--- a/src/api/flags.js
+++ b/src/api/flags.js
@@ -15,8 +15,8 @@ flagsApi.create = async (caller, data) => {
 
     await flags.validate({
         uid: caller.uid,
-        type: type,
-        id: id,
+        type,
+        id,
     });
 
     const flagObj = await flags.create(type, id, caller.uid, reason);
@@ -61,7 +61,7 @@ flagsApi.appendNote = async (caller, data) => {
         flags.getNotes(data.flagId),
         flags.getHistory(data.flagId),
     ]);
-    return { notes: notes, history: history };
+    return { notes, history };
 };
 
 flagsApi.deleteNote = async (caller, data) => {
@@ -80,5 +80,5 @@ flagsApi.deleteNote = async (caller, data) => {
         flags.getNotes(data.flagId),
         flags.getHistory(data.flagId),
     ]);
-    return { notes: notes, history: history };
+    return { notes, history };
 };

--- a/src/api/groups.js
+++ b/src/api/groups.js
@@ -60,7 +60,7 @@ groupsAPI.delete = async function (caller, data) {
 
     await groups.destroy(groupName);
     logGroupEvent(caller, 'group-delete', {
-        groupName: groupName,
+        groupName,
     });
 };
 
@@ -97,10 +97,10 @@ groupsAPI.join = async function (caller, data) {
 
     const isSelf = parseInt(caller.uid, 10) === parseInt(data.uid, 10);
     if (!meta.config.allowPrivateGroups && isSelf) {
-        // all groups are public!
+    // all groups are public!
         await groups.join(groupName, data.uid);
         logGroupEvent(caller, 'group-join', {
-            groupName: groupName,
+            groupName,
             targetUid: data.uid,
         });
         return;
@@ -113,13 +113,13 @@ groupsAPI.join = async function (caller, data) {
     if ((!groupData.private && isSelf) || isCallerAdmin || isCallerOwner) {
         await groups.join(groupName, data.uid);
         logGroupEvent(caller, 'group-join', {
-            groupName: groupName,
+            groupName,
             targetUid: data.uid,
         });
     } else if (isSelf) {
         await groups.requestMembership(groupName, caller.uid);
         logGroupEvent(caller, 'group-request-membership', {
-            groupName: groupName,
+            groupName,
             targetUid: data.uid,
         });
     }
@@ -184,7 +184,7 @@ groupsAPI.leave = async function (caller, data) {
     await notifications.push(notification, uids);
 
     logGroupEvent(caller, 'group-leave', {
-        groupName: groupName,
+        groupName,
         targetUid: data.uid,
     });
 };
@@ -195,7 +195,7 @@ groupsAPI.grant = async (caller, data) => {
 
     await groups.ownership.grant(data.uid, groupName);
     logGroupEvent(caller, 'group-owner-grant', {
-        groupName: groupName,
+        groupName,
         targetUid: data.uid,
     });
 };
@@ -206,7 +206,7 @@ groupsAPI.rescind = async (caller, data) => {
 
     await groups.ownership.rescind(data.uid, groupName);
     logGroupEvent(caller, 'group-owner-rescind', {
-        groupName: groupName,
+        groupName,
         targetUid: data.uid,
     });
 };

--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -36,12 +36,12 @@ exports.buildReqObject = (req, payload) => {
         body: payload || req.body,
         session: req.session,
         ip: req.ip,
-        host: host,
+        host,
         protocol: encrypted ? 'https' : 'http',
         secure: encrypted,
         url: referer,
         path: referer.slice(referer.indexOf(host) + host.length),
-        headers: headers,
+        headers,
     };
 };
 
@@ -80,7 +80,7 @@ async function logTopicAction(action, req, tid, title) {
         type: `topic-${action}`,
         uid: req.uid,
         ip: req.ip,
-        tid: tid,
+        tid,
         title: String(title),
     });
 }
@@ -119,7 +119,7 @@ exports.postCommand = async function (caller, command, eventName, notification, 
         filter:post.unbookmark
      */
     const filteredData = await plugins.hooks.fire(`filter:post.${command}`, {
-        data: data,
+        data,
         uid: caller.uid,
     });
     return await executeCommand(caller, command, eventName, notification, filteredData.data);

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -73,7 +73,7 @@ postsAPI.edit = async function (caller, data) {
     const selfPost = parseInt(caller.uid, 10) === parseInt(editResult.post.uid, 10);
     if (!selfPost && editResult.post.changed) {
         await events.log({
-            type: `post-edit`,
+            type: 'post-edit',
             uid: caller.uid,
             ip: caller.ip,
             pid: editResult.post.pid,
@@ -214,7 +214,7 @@ async function isMainAndLastPost(pid) {
         posts.getTopicFields(pid, ['postcount']),
     ]);
     return {
-        isMain: isMain,
+        isMain,
         isLast: topicData && topicData.postcount === 1,
     };
 }
@@ -240,7 +240,7 @@ postsAPI.move = async function (caller, data) {
         posts.getPostField(data.pid, 'deleted'),
         topics.getTopicField(data.tid, 'deleted'),
         await events.log({
-            type: `post-move`,
+            type: 'post-move',
             uid: caller.uid,
             ip: caller.ip,
             pid: data.pid,
@@ -306,9 +306,9 @@ postsAPI.getDiffs = async (caller, data) => {
     timestamps.push(String(post.timestamp));
 
     return {
-        timestamps: timestamps,
+        timestamps,
         revisions: timestamps.map((timestamp, idx) => ({
-            timestamp: timestamp,
+            timestamp,
             username: usernames[idx],
         })),
         // Only admins, global mods and moderator of that cid can delete a diff

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -78,7 +78,7 @@ usersAPI.update = async function (caller, data) {
 };
 
 usersAPI.delete = async function (caller, { uid, password }) {
-    await processDeletion({ uid: uid, method: 'delete', password, caller });
+    await processDeletion({ uid, method: 'delete', password, caller });
 };
 
 usersAPI.deleteContent = async function (caller, { uid, password }) {
@@ -346,7 +346,7 @@ async function processDeletion({ uid, method, password, caller }) {
 
     plugins.hooks.fire('action:user.delete', {
         callerUid: caller.uid,
-        uid: uid,
+        uid,
         ip: caller.ip,
         user: userData,
     });
@@ -398,7 +398,7 @@ usersAPI.search = async function (caller, data) {
         searchBy: data.searchBy || 'username',
         page: data.page || 1,
         sortBy: data.sortBy || 'lastonline',
-        filters: filters,
+        filters,
     });
 };
 
@@ -425,7 +425,7 @@ usersAPI.changePicture = async (caller, data) => {
     } else {
         const returnData = await plugins.hooks.fire('filter:user.getPicture', {
             uid: caller.uid,
-            type: type,
+            type,
             picture: undefined,
         });
         picture = returnData && returnData.picture;
@@ -438,7 +438,7 @@ usersAPI.changePicture = async (caller, data) => {
 
     await user.updateProfile(caller.uid, {
         uid: data.uid,
-        picture: picture,
+        picture,
         'icon:bgColor': data.bgColor,
     }, ['picture', 'icon:bgColor']);
 };

--- a/src/batch.js
+++ b/src/batch.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const util = require('util');
@@ -40,7 +39,7 @@ exports.processSortedSet = async function (setKey, process, options) {
     }
 
     while (true) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         const ids = await db[`getSortedSetRange${options.withScores ? 'WithScores' : ''}`](setKey, start, stop);
         if (!ids.length || options.doneIf(start, stop, ids)) {
             return;

--- a/src/categories/create.js
+++ b/src/categories/create.js
@@ -25,19 +25,19 @@ module.exports = function (Categories) {
         const colours = Categories.assignColours();
 
         let category = {
-            cid: cid,
+            cid,
             name: data.name,
             description: data.description ? data.description : '',
             descriptionParsed: data.descriptionParsed ? data.descriptionParsed : '',
             icon: data.icon ? data.icon : '',
             bgColor: data.bgColor || colours[0],
             color: data.color || colours[1],
-            slug: slug,
-            parentCid: parentCid,
+            slug,
+            parentCid,
             topic_count: 0,
             post_count: 0,
             disabled: data.disabled ? 1 : 0,
-            order: order,
+            order,
             link: data.link || '',
             numRecentReplies: 1,
             class: (data.class ? data.class : 'col-md-3 col-xs-6'),
@@ -72,11 +72,11 @@ module.exports = function (Categories) {
         const guestPrivileges = ['groups:find', 'groups:read', 'groups:topics:read'];
 
         const result = await plugins.hooks.fire('filter:category.create', {
-            category: category,
-            data: data,
-            defaultPrivileges: defaultPrivileges,
-            modPrivileges: modPrivileges,
-            guestPrivileges: guestPrivileges,
+            category,
+            data,
+            defaultPrivileges,
+            modPrivileges,
+            guestPrivileges,
         });
         category = result.category;
 
@@ -108,7 +108,7 @@ module.exports = function (Categories) {
             await duplicateCategoriesChildren(category.cid, data.cloneFromCid, data.uid);
         }
 
-        plugins.hooks.fire('action:category.create', { category: category });
+        plugins.hooks.fire('action:category.create', { category });
         return category;
     };
 
@@ -178,9 +178,9 @@ module.exports = function (Categories) {
             destination.parentCid = source.parentCid || 0;
         }
         await plugins.hooks.fire('filter:categories.copySettingsFrom', {
-            source: source,
-            destination: destination,
-            copyParent: copyParent,
+            source,
+            destination,
+            copyParent,
         });
 
         await db.setObject(`category:${toCid}`, destination);
@@ -213,9 +213,9 @@ module.exports = function (Categories) {
 
         const data = await plugins.hooks.fire('filter:categories.copyPrivilegesFrom', {
             privileges: privsToCopy,
-            fromCid: fromCid,
-            toCid: toCid,
-            group: group,
+            fromCid,
+            toCid,
+            group,
         });
         if (group) {
             await copyPrivilegesByGroup(data.privileges, data.fromCid, data.toCid, group);

--- a/src/categories/data.js
+++ b/src/categories/data.js
@@ -22,10 +22,10 @@ module.exports = function (Categories) {
         const keys = cids.map(cid => `category:${cid}`);
         const categories = await db.getObjects(keys, fields);
         const result = await plugins.hooks.fire('filter:category.getFields', {
-            cids: cids,
-            categories: categories,
-            fields: fields,
-            keys: keys,
+            cids,
+            categories,
+            fields,
+            keys,
         });
         result.categories.forEach(category => modifyCategory(category, fields));
         return result.categories;

--- a/src/categories/delete.js
+++ b/src/categories/delete.js
@@ -23,7 +23,7 @@ module.exports = function (Categories) {
         });
         const categoryData = await Categories.getCategoryData(cid);
         await purgeCategory(cid, categoryData);
-        plugins.hooks.fire('action:category.delete', { cid: cid, uid: uid, category: categoryData });
+        plugins.hooks.fire('action:category.delete', { cid, uid, category: categoryData });
     };
 
     async function purgeCategory(cid, categoryData) {

--- a/src/categories/index.js
+++ b/src/categories/index.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -60,7 +59,7 @@ Categories.getCategoryById = async function (data) {
 
     calculateTopicPostCount(category);
     const result = await plugins.hooks.fire('filter:category.get', {
-        category: category,
+        category,
         ...data,
     });
     return result.category;
@@ -247,7 +246,7 @@ Categories.getParentCids = async function (currentCid) {
     let cid = currentCid;
     const parents = [];
     while (parseInt(cid, 10)) {
-        // eslint-disable-next-line
+    // eslint-disable-next-line
         cid = await Categories.getCategoryField(cid, 'parentCid');
         if (cid) {
             parents.unshift(cid);

--- a/src/categories/recentreplies.js
+++ b/src/categories/recentreplies.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const winston = require('winston');
@@ -13,7 +12,7 @@ const batch = require('../batch');
 
 module.exports = function (Categories) {
     Categories.getRecentReplies = async function (cid, uid, start, stop) {
-        // backwards compatibility, treat start as count
+    // backwards compatibility, treat start as count
         if (stop === undefined && start > 0) {
             winston.warn('[Categories.getRecentReplies] 3 params deprecated please use Categories.getRecentReplies(cid, uid, start, stop)');
             stop = start - 1;
@@ -40,7 +39,7 @@ module.exports = function (Categories) {
         if (numRecentReplies > 0) {
             await db.sortedSetAdd(`cid:${cid}:recent_tids`, Date.now(), tid);
         }
-        await plugins.hooks.fire('action:categories.updateRecentTid', { cid: cid, tid: tid });
+        await plugins.hooks.fire('action:categories.updateRecentTid', { cid, tid });
     };
 
     Categories.updateRecentTidForCid = async function (cid) {
@@ -76,8 +75,8 @@ module.exports = function (Categories) {
         if (plugins.hooks.hasListeners('filter:categories.getRecentTopicReplies')) {
             const result = await plugins.hooks.fire('filter:categories.getRecentTopicReplies', {
                 categories: categoriesToLoad,
-                uid: uid,
-                query: query,
+                uid,
+                query,
                 keys: [],
             });
             keys = result.keys;

--- a/src/categories/search.js
+++ b/src/categories/search.js
@@ -18,9 +18,9 @@ module.exports = function (Categories) {
         let cids = await findCids(query, data.hardCap);
 
         const result = await plugins.hooks.fire('filter:categories.search', {
-            data: data,
-            cids: cids,
-            uid: uid,
+            data,
+            cids,
+            uid,
         });
         cids = await privileges.categories.filterCids('find', result.cids, uid);
 

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -47,11 +47,11 @@ module.exports = function (Categories) {
         if (plugins.hooks.hasListeners('filter:categories.getTopicIds')) {
             const result = await plugins.hooks.fire('filter:categories.getTopicIds', {
                 tids: [],
-                data: data,
+                data,
                 pinnedTids: pinnedTidsOnPage,
                 allPinnedTids: pinnedTids,
-                totalPinnedCount: totalPinnedCount,
-                normalTidsToGet: normalTidsToGet,
+                totalPinnedCount,
+                normalTidsToGet,
             });
             return result && result.tids;
         }
@@ -66,7 +66,7 @@ module.exports = function (Categories) {
         const reverse = direction === 'highest-to-lowest';
         if (Array.isArray(set)) {
             const weights = set.map((s, index) => (index ? 0 : 1));
-            normalTids = await db[reverse ? 'getSortedSetRevIntersect' : 'getSortedSetIntersect']({ sets: set, start: start, stop: stop, weights: weights });
+            normalTids = await db[reverse ? 'getSortedSetRevIntersect' : 'getSortedSetIntersect']({ sets: set, start, stop, weights });
         } else {
             normalTids = await db[reverse ? 'getSortedSetRevRange' : 'getSortedSetRange'](set, start, stop);
         }
@@ -78,7 +78,7 @@ module.exports = function (Categories) {
         if (plugins.hooks.hasListeners('filter:categories.getTopicCount')) {
             const result = await plugins.hooks.fire('filter:categories.getTopicCount', {
                 topicCount: data.category.topic_count,
-                data: data,
+                data,
             });
             return result && result.topicCount;
         }
@@ -117,8 +117,8 @@ module.exports = function (Categories) {
         }
 
         const result = await plugins.hooks.fire('filter:categories.buildTopicsSortedSet', {
-            set: set,
-            data: data,
+            set,
+            data,
         });
         return result && result.set;
     };
@@ -127,8 +127,8 @@ module.exports = function (Categories) {
         sort = sort || 'newest_to_oldest';
         const direction = ['newest_to_oldest', 'most_posts', 'most_votes', 'most_views'].includes(sort) ? 'highest-to-lowest' : 'lowest-to-highest';
         const result = await plugins.hooks.fire('filter:categories.getSortedSetRangeDirection', {
-            sort: sort,
-            direction: direction,
+            sort,
+            direction,
         });
         return result && result.direction;
     };
@@ -141,7 +141,7 @@ module.exports = function (Categories) {
         if (plugins.hooks.hasListeners('filter:categories.getPinnedTids')) {
             const result = await plugins.hooks.fire('filter:categories.getPinnedTids', {
                 pinnedTids: [],
-                data: data,
+                data,
             });
             return result && result.pinnedTids;
         }

--- a/src/categories/update.js
+++ b/src/categories/update.js
@@ -25,7 +25,7 @@ module.exports = function (Categories) {
             const translated = await translator.translate(modifiedFields.name);
             modifiedFields.slug = `${cid}/${slugify(translated)}`;
         }
-        const result = await plugins.hooks.fire('filter:category.update', { cid: cid, category: modifiedFields });
+        const result = await plugins.hooks.fire('filter:category.update', { cid, category: modifiedFields });
 
         const { category } = result;
         const fields = Object.keys(category);
@@ -39,7 +39,7 @@ module.exports = function (Categories) {
             // eslint-disable-next-line no-await-in-loop
             await updateCategoryField(cid, key, category[key]);
         }
-        plugins.hooks.fire('action:category.update', { cid: cid, modified: category });
+        plugins.hooks.fire('action:category.update', { cid, modified: category });
     }
 
     async function updateCategoryField(cid, key, value) {

--- a/src/cli/package-install.js
+++ b/src/cli/package-install.js
@@ -88,7 +88,7 @@ pkgInstall.getPackageManager = () => {
 
         return nconf.get('package_manager') || 'npm';
     } catch (e) {
-        // nconf not installed or other unexpected error/exception
+    // nconf not installed or other unexpected error/exception
         return getPackageManagerByLockfile() || 'npm';
     }
 };

--- a/src/cli/upgrade-plugins.js
+++ b/src/cli/upgrade-plugins.js
@@ -48,7 +48,6 @@ async function getInstalledPlugins() {
     bundled = Object.keys(JSON.parse(bundled).dependencies)
         .filter(pkgName => pluginNamePattern.test(pkgName));
 
-
     // Whittle down deps to send back only extraneously installed plugins/themes/etc
     const checklist = deps.filter((pkgName) => {
         if (bundled.includes(pkgName)) {
@@ -109,8 +108,8 @@ async function checkPlugins() {
         if (suggestObj.code === 'match-found' && semver.gt(suggested, current)) {
             return {
                 name: suggestObj.package,
-                current: current,
-                suggested: suggested,
+                current,
+                suggested,
             };
         }
         return null;

--- a/src/cli/user.js
+++ b/src/cli/user.js
@@ -204,7 +204,7 @@ ${pwGenerated ? ` Generated password: ${password}` : ''}`);
 
         const userExists = await user.exists(uid);
         if (!userExists) {
-            return winston.error(`[userCmd/reset] A user with given uid does not exists.`);
+            return winston.error('[userCmd/reset] A user with given uid does not exists.');
         }
 
         let pwGenerated = false;
@@ -240,7 +240,7 @@ ${pwGenerated ? ` Generated password: ${password}` : ''}`);
 
         const userExists = await user.exists(uids);
         if (!userExists || userExists.some(r => r === false)) {
-            return winston.error(`[userCmd/reset] A user with given uid does not exists.`);
+            return winston.error('[userCmd/reset] A user with given uid does not exists.');
         }
 
         await db.initSessionStore();
@@ -249,15 +249,15 @@ ${pwGenerated ? ` Generated password: ${password}` : ''}`);
         switch (type) {
         case 'purge':
             await Promise.all(uids.map(uid => user.delete(adminUid, uid)));
-            winston.info(`[userCmd/delete] User(s) with their content has been deleted.`);
+            winston.info('[userCmd/delete] User(s) with their content has been deleted.');
             break;
         case 'account':
             await Promise.all(uids.map(uid => user.deleteAccount(uid)));
-            winston.info(`[userCmd/delete] User(s) has been deleted, their content left intact.`);
+            winston.info('[userCmd/delete] User(s) has been deleted, their content left intact.');
             break;
         case 'content':
             await Promise.all(uids.map(uid => user.deleteContent(adminUid, uid)));
-            winston.info(`[userCmd/delete] User(s)' content has been deleted.`);
+            winston.info('[userCmd/delete] User(s)\' content has been deleted.');
             break;
         }
     }

--- a/src/controllers/404.js
+++ b/src/controllers/404.js
@@ -15,8 +15,8 @@ exports.handle404 = function handle404(req, res) {
 
     if (plugins.hooks.hasListeners('action:meta.override404')) {
         return plugins.hooks.fire('action:meta.override404', {
-            req: req,
-            res: res,
+            req,
+            res,
             error: {},
         });
     }

--- a/src/controllers/accounts/blocks.js
+++ b/src/controllers/accounts/blocks.js
@@ -20,10 +20,10 @@ blocksController.getBlocks = async function (req, res, next) {
     }
     const uids = await user.blocks.list(userData.uid);
     const data = await plugins.hooks.fire('filter:user.getBlocks', {
-        uids: uids,
+        uids,
         uid: userData.uid,
-        start: start,
-        stop: stop,
+        start,
+        stop,
     });
 
     data.uids = data.uids.slice(start, stop + 1);

--- a/src/controllers/accounts/categories.js
+++ b/src/controllers/accounts/categories.js
@@ -25,7 +25,6 @@ categoriesController.get = async function (req, res, next) {
     const stop = start + meta.config.categoriesPerPage - 1;
     const categoriesData = allCategoriesData.slice(start, stop + 1);
 
-
     categoriesData.forEach((category) => {
         if (category) {
             category.isIgnored = states[category.cid] === categories.watchStates.ignoring;

--- a/src/controllers/accounts/chats.js
+++ b/src/controllers/accounts/chats.js
@@ -29,14 +29,14 @@ chatsController.get = async function (req, res, next) {
     if (!req.params.roomid) {
         return res.render('chats', {
             rooms: recentChats.rooms,
-            uid: uid,
+            uid,
             userslug: req.params.userslug,
             nextStart: recentChats.nextStart,
             allowed: true,
             title: '[[pages:chats]]',
         });
     }
-    const room = await messaging.loadRoom(req.uid, { uid: uid, roomId: req.params.roomid });
+    const room = await messaging.loadRoom(req.uid, { uid, roomId: req.params.roomid });
     if (!room) {
         return next();
     }

--- a/src/controllers/accounts/helpers.js
+++ b/src/controllers/accounts/helpers.js
@@ -87,7 +87,7 @@ helpers.getUserDataByUserSlug = async function (userslug, callerUID, query = {})
         moderator: isModerator,
         globalMod: isGlobalModerator,
         admin: isAdmin,
-        canViewInfo: canViewInfo,
+        canViewInfo,
     });
 
     userData.sso = results.sso.associations;
@@ -116,9 +116,9 @@ helpers.getUserDataByUserSlug = async function (userslug, callerUID, query = {})
     await getCounts(userData, callerUID);
 
     const hookData = await plugins.hooks.fire('filter:helpers.getUserDataByUserSlug', {
-        userData: userData,
-        callerUID: callerUID,
-        query: query,
+        userData,
+        callerUID,
+        query,
     });
     return hookData.userData;
 };
@@ -139,7 +139,7 @@ async function getAllData(uid, callerUID) {
         ips: user.getIPs(uid, 4),
         profile_menu: getProfileMenu(uid, callerUID),
         groups: groups.getUserGroups([uid]),
-        sso: plugins.hooks.fire('filter:auth.list', { uid: uid, associations: [] }),
+        sso: plugins.hooks.fire('filter:auth.list', { uid, associations: [] }),
         canEdit: privileges.users.canEdit(callerUID, uid),
         canBanUser: privileges.users.canBanUser(callerUID, uid),
         canMuteUser: privileges.users.canMuteUser(callerUID, uid),
@@ -226,9 +226,9 @@ async function getProfileMenu(uid, callerUID) {
     }
 
     return await plugins.hooks.fire('filter:user.profileMenu', {
-        uid: uid,
-        callerUID: callerUID,
-        links: links,
+        uid,
+        callerUID,
+        links,
     });
 }
 
@@ -246,7 +246,7 @@ async function parseAboutMe(userData) {
 
 function filterLinks(links, states) {
     return links.filter((link, index) => {
-        // Default visibility
+    // Default visibility
         link.visibility = {
             self: true,
             other: true,

--- a/src/controllers/accounts/info.js
+++ b/src/controllers/accounts/info.js
@@ -50,5 +50,5 @@ async function getNotes(userData, start, stop) {
         user.getModerationNotes(userData.uid, start, stop),
         db.sortedSetCard(`uid:${userData.uid}:moderation:notes`),
     ]);
-    return { notes: notes, count: count };
+    return { notes, count };
 }

--- a/src/controllers/accounts/notifications.js
+++ b/src/controllers/accounts/notifications.js
@@ -32,8 +32,8 @@ notificationsController.get = async function (req, res, next) {
 
     const [filters, isPrivileged] = await Promise.all([
         plugins.hooks.fire('filter:notifications.addFilters', {
-            regularFilters: regularFilters,
-            moderatorFilters: moderatorFilters,
+            regularFilters,
+            moderatorFilters,
             uid: req.uid,
         }),
         user.isPrivileged(req.uid),
@@ -60,12 +60,12 @@ notificationsController.get = async function (req, res, next) {
     notifications = notifications.slice(start, stop + 1);
 
     res.render('notifications', {
-        notifications: notifications,
+        notifications,
         pagination: pagination.create(page, pageCount, req.query),
         filters: allFilters,
-        regularFilters: regularFilters,
-        moderatorFilters: moderatorFilters,
-        selectedFilter: selectedFilter,
+        regularFilters,
+        moderatorFilters,
+        selectedFilter,
         title: '[[pages:notifications]]',
         breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[pages:notifications]]' }]),
     });

--- a/src/controllers/accounts/posts.js
+++ b/src/controllers/accounts/posts.js
@@ -109,7 +109,7 @@ const templateToData = {
             const sortSet = map[sort];
             let tids = await db.getSortedSetRevRange(set, 0, -1);
             const scores = await db.sortedSetScores(sortSet, tids);
-            tids = tids.map((tid, i) => ({ tid: tid, score: scores[i] }))
+            tids = tids.map((tid, i) => ({ tid, score: scores[i] }))
                 .sort((a, b) => b.score - a.score)
                 .slice(start, stop + 1)
                 .map(t => t.tid);
@@ -193,13 +193,13 @@ async function getPostsFromUserSet(template, req, res, next) {
     let result;
     if (plugins.hooks.hasListeners('filter:account.getPostsFromUserSet')) {
         result = await plugins.hooks.fire('filter:account.getPostsFromUserSet', {
-            req: req,
-            template: template,
-            userData: userData,
-            settings: settings,
-            data: data,
-            start: start,
-            stop: stop,
+            req,
+            template,
+            userData,
+            settings,
+            data,
+            start,
+            stop,
             itemCount: 0,
             itemData: [],
         });

--- a/src/controllers/accounts/profile.js
+++ b/src/controllers/accounts/profile.js
@@ -106,7 +106,7 @@ async function getPosts(callerUid, userData, setSuffix) {
     const cidToCanSchedule = _.zipObject(cids, canSchedule);
 
     do {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         let pids = await db.getSortedSetRevRange(keys, start, start + count - 1);
         if (!pids.length || pids.length < count) {
             hasMorePosts = false;

--- a/src/controllers/accounts/settings.js
+++ b/src/controllers/accounts/settings.js
@@ -34,7 +34,7 @@ settingsController.get = async function (req, res, next) {
     }
 
     const data = await plugins.hooks.fire('filter:user.customSettings', {
-        settings: settings,
+        settings,
         customSettings: [],
         uid: req.uid,
     });
@@ -101,7 +101,7 @@ settingsController.get = async function (req, res, next) {
     ];
 
     userData.upvoteNotifFreq = notifFreqOptions.map(
-        name => ({ name: name, selected: name === userData.settings.upvoteNotifFreq })
+        name => ({ name, selected: name === userData.settings.upvoteNotifFreq })
     );
 
     userData.categoryWatchState = { [userData.settings.categoryWatchState]: true };
@@ -192,7 +192,7 @@ async function getNotificationSettings(userData) {
     }
     const results = await plugins.hooks.fire('filter:user.notificationTypes', {
         types: notifications.baseTypes.slice(),
-        privilegedTypes: privilegedTypes,
+        privilegedTypes,
     });
 
     function modifyType(type) {

--- a/src/controllers/admin/admins-mods.js
+++ b/src/controllers/admin/admins-mods.js
@@ -35,10 +35,10 @@ AdminsMods.get = async function (req, res) {
     ]);
 
     res.render('admin/manage/admins-mods', {
-        admins: admins,
-        globalMods: globalMods,
+        admins,
+        globalMods,
         categoryMods: moderators,
-        selectedCategory: selectedCategory,
+        selectedCategory,
         pagination: pagination.create(page, pageCount, req.query),
         breadcrumbs: crumbs,
     });

--- a/src/controllers/admin/categories.js
+++ b/src/controllers/admin/categories.js
@@ -27,9 +27,9 @@ categoriesController.get = async function (req, res, next) {
     category.parent = parent[0];
 
     const data = await plugins.hooks.fire('filter:admin.category.get', {
-        req: req,
-        res: res,
-        category: category,
+        req,
+        res,
+        category,
         customClasses: [],
     });
     data.category.name = translator.escape(String(data.category.name));
@@ -64,7 +64,7 @@ categoriesController.getAll = async function (req, res) {
         'color', 'bgColor', 'backgroundImage', 'imageClass', 'subCategoriesPerPage',
     ];
     const categoriesData = await categories.getCategoriesFields(cids, fields);
-    const result = await plugins.hooks.fire('filter:admin.categories.get', { categories: categoriesData, fields: fields });
+    const result = await plugins.hooks.fire('filter:admin.categories.get', { categories: categoriesData, fields });
     let tree = categories.getTree(result.categories, rootParent);
     const cidsCount = rootCid && tree[0] ? tree[0].children.length : tree.length;
 
@@ -97,7 +97,7 @@ categoriesController.getAll = async function (req, res) {
     const crumbs = await buildBreadcrumbs(selectedCategory, '/admin/manage/categories');
     res.render('admin/manage/categories', {
         categoriesTree: tree,
-        selectedCategory: selectedCategory,
+        selectedCategory,
         breadcrumbs: crumbs,
         pagination: pagination.create(page, pageCount, req.query),
         categoriesPerPage: meta.config.categoriesPerPage,
@@ -123,7 +123,7 @@ async function buildBreadcrumbs(categoryData, url) {
     });
     crumbs.unshift({
         text: '[[admin/manage/categories:top-level]]',
-        url: url,
+        url,
     });
 
     return crumbs.concat(breadcrumbs);
@@ -137,7 +137,7 @@ categoriesController.getAnalytics = async function (req, res) {
         analytics.getCategoryAnalytics(req.params.category_id),
     ]);
     res.render('admin/manage/category-analytics', {
-        name: name,
+        name,
         analytics: analyticsData,
     });
 };

--- a/src/controllers/admin/dashboard.js
+++ b/src/controllers/admin/dashboard.js
@@ -30,17 +30,17 @@ dashboardController.get = async function (req, res) {
     const version = nconf.get('version');
 
     res.render('admin/dashboard', {
-        version: version,
+        version,
         lookupFailed: latestVersion === null,
-        latestVersion: latestVersion,
+        latestVersion,
         upgradeAvailable: latestVersion && semver.gt(latestVersion, version),
         currentPrerelease: versions.isPrerelease.test(version),
-        notices: notices,
-        stats: stats,
+        notices,
+        stats,
         canRestart: !!process.send,
-        lastrestart: lastrestart,
+        lastrestart,
         showSystemControls: isAdmin,
-        popularSearches: popularSearches,
+        popularSearches,
     });
 };
 
@@ -113,8 +113,8 @@ dashboardController.getAnalytics = async (req, res, next) => {
         query: {
             set: req.query.set,
             units: req.query.units,
-            until: until,
-            count: count,
+            until,
+            count,
         },
         result: payload,
     });

--- a/src/controllers/admin/events.js
+++ b/src/controllers/admin/events.js
@@ -38,7 +38,7 @@ eventsController.get = async function (req, res) {
     res.render('admin/advanced/events', {
         events: eventData,
         pagination: pagination.create(page, pageCount, req.query),
-        types: types,
+        types,
         query: req.query,
     });
 };

--- a/src/controllers/admin/groups.js
+++ b/src/controllers/admin/groups.js
@@ -51,7 +51,7 @@ groupsController.get = async function (req, res, next) {
     }));
 
     res.render('admin/manage/group', {
-        group: group,
+        group,
         groupNames: groupNameData,
         allowPrivateGroups: meta.config.allowPrivateGroups,
         maximumGroupNameLength: meta.config.maximumGroupNameLength,

--- a/src/controllers/admin/hooks.js
+++ b/src/controllers/admin/hooks.js
@@ -28,5 +28,5 @@ hooksController.get = function (req, res) {
 
     hooks.sort((a, b) => b.count - a.count);
 
-    res.render('admin/advanced/hooks', { hooks: hooks });
+    res.render('admin/advanced/hooks', { hooks });
 };

--- a/src/controllers/admin/info.js
+++ b/src/controllers/admin/info.js
@@ -40,7 +40,7 @@ infoController.get = function (req, res) {
             info: data,
             infoJSON: JSON.stringify(data, null, 4),
             host: os.hostname(),
-            port: port,
+            port,
             nodeCount: data.length,
             timeout: timeoutMS,
             ip: req.ip,
@@ -52,7 +52,7 @@ pubsub.on('sync:node:info:start', async () => {
     try {
         const data = await getNodeInfo();
         data.id = `${os.hostname()}:${nconf.get('port')}`;
-        pubsub.publish('sync:node:info:end', { data: data, id: data.id });
+        pubsub.publish('sync:node:info:end', { data, id: data.id });
     } catch (err) {
         winston.error(err.stack);
     }
@@ -140,5 +140,5 @@ async function getGitInfo() {
         getAsync('git rev-parse HEAD'),
         getAsync('git rev-parse --abbrev-ref HEAD'),
     ]);
-    return { hash: hash, hashShort: hash.slice(0, 6), branch: branch };
+    return { hash, hashShort: hash.slice(0, 6), branch };
 }

--- a/src/controllers/admin/settings.js
+++ b/src/controllers/admin/settings.js
@@ -24,7 +24,7 @@ settingsController.email = async (req, res) => {
     const emails = await emailer.getTemplates(meta.config);
 
     res.render('admin/settings/email', {
-        emails: emails,
+        emails,
         sendable: emails.filter(e => !e.path.includes('_plaintext') && !e.path.includes('partials')).map(tpl => tpl.path),
         services: emailer.listServices(),
     });
@@ -37,7 +37,7 @@ settingsController.user = async (req, res) => {
         label: `[[notifications:${type}]]`,
     }));
     res.render('admin/settings/user', {
-        notificationSettings: notificationSettings,
+        notificationSettings,
     });
 };
 
@@ -99,12 +99,12 @@ settingsController.navigation = async function (req, res) {
 
 settingsController.homepage = async function (req, res) {
     const routes = await helpers.getHomePageRoutes(req.uid);
-    res.render('admin/settings/homepage', { routes: routes });
+    res.render('admin/settings/homepage', { routes });
 };
 
 settingsController.social = async function (req, res) {
     const posts = await social.getPostSharing();
     res.render('admin/settings/social', {
-        posts: posts,
+        posts,
     });
 };

--- a/src/controllers/admin/tags.js
+++ b/src/controllers/admin/tags.js
@@ -6,5 +6,5 @@ const tagsController = module.exports;
 
 tagsController.get = async function (req, res) {
     const tags = await topics.getTags(0, 199);
-    res.render('admin/manage/tags', { tags: tags });
+    res.render('admin/manage/tags', { tags });
 };

--- a/src/controllers/admin/uploads.js
+++ b/src/controllers/admin/uploads.js
@@ -55,7 +55,7 @@ uploadsController.get = async function (req, res, next) {
         res.render('admin/manage/uploads', {
             currentFolder: currentFolder.replace(nconf.get('upload_path'), ''),
             showPids: files.length && files[0].hasOwnProperty('inPids'),
-            files: files,
+            files,
             breadcrumbs: buildBreadcrumbs(currentFolder),
             pagination: pagination.create(page, Math.ceil(itemCount / itemsPerPage), req.query),
         });
@@ -97,7 +97,7 @@ async function getFileData(currentDir, file) {
     return {
         name: file,
         path: pathToFile.replace(path.join(nconf.get('upload_path'), '/'), ''),
-        url: url,
+        url,
         fileCount: Math.max(0, filesInDir.length - 1), // ignore .gitignore
         size: stat.size,
         sizeHumanReadable: `${(stat.size / 1024).toFixed(1)}KiB`,
@@ -166,7 +166,6 @@ uploadsController.uploadTouchIcon = async function (req, res, next) {
         }
     }
 };
-
 
 uploadsController.uploadMaskableIcon = async function (req, res, next) {
     const uploadedFile = req.files.files[0];
@@ -239,7 +238,7 @@ async function uploadImage(filename, folder, uploadedFile, req, res, next) {
     let imageData;
     try {
         if (plugins.hooks.hasListeners('filter:uploadImage')) {
-            imageData = await plugins.hooks.fire('filter:uploadImage', { image: uploadedFile, uid: req.uid, folder: folder });
+            imageData = await plugins.hooks.fire('filter:uploadImage', { image: uploadedFile, uid: req.uid, folder });
         } else {
             imageData = await file.saveFileToLocal(filename, folder, uploadedFile.path);
         }

--- a/src/controllers/admin/users.js
+++ b/src/controllers/admin/users.js
@@ -82,9 +82,9 @@ async function getUsers(req, res) {
             const weights = set.map((s, index) => (index ? 0 : 1));
             uids = await db[reverse ? 'getSortedSetRevIntersect' : 'getSortedSetIntersect']({
                 sets: set,
-                start: start,
-                stop: stop,
-                weights: weights,
+                start,
+                stop,
+                weights,
             });
         } else {
             uids = await db[reverse ? 'getSortedSetRevRange' : 'getSortedSetRange'](set, start, stop);
@@ -101,11 +101,11 @@ async function getUsers(req, res) {
 
     await render(req, res, {
         users: users.filter(user => user && parseInt(user.uid, 10)),
-        page: page,
+        page,
         pageCount: Math.max(1, Math.ceil(count / resultsPerPage)),
-        resultsPerPage: resultsPerPage,
-        reverse: reverse,
-        sortBy: sortBy,
+        resultsPerPage,
+        reverse,
+        sortBy,
     });
 }
 
@@ -123,10 +123,10 @@ usersController.search = async function (req, res) {
         query: req.query.query,
         searchBy: req.query.searchBy,
         sortBy: req.query.sortBy,
-        sortDirection: sortDirection,
+        sortDirection,
         filters: req.query.filters,
-        page: page,
-        resultsPerPage: resultsPerPage,
+        page,
+        resultsPerPage,
         findUids: async function (query, searchBy, hardCap) {
             if (!query || query.length < 2) {
                 return [];
@@ -222,7 +222,7 @@ async function getInvites() {
 
     invitations.forEach((invites, index) => {
         invites.invitations = invites.invitations.map((email, i) => ({
-            email: email,
+            email,
             username: usernames[index][i] === '[[global:guest]]' ? '' : usernames[index][i],
         }));
     });

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -125,7 +125,7 @@ apiController.getConfig = async function (req, res) {
 
 apiController.getModerators = async function (req, res) {
     const moderators = await categories.getModerators(req.params.cid);
-    res.json({ moderators: moderators });
+    res.json({ moderators });
 };
 
 require('../promisify')(apiController, ['getConfig', 'getObject', 'getModerators']);

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const nconf = require('nconf');
 const validator = require('validator');
 const qs = require('querystring');
@@ -73,14 +72,14 @@ categoryController.get = async function (req, res, next) {
 
     const categoryData = await categories.getCategoryById({
         uid: req.uid,
-        cid: cid,
-        start: start,
-        stop: stop,
+        cid,
+        start,
+        stop,
         sort: req.query.sort || userSettings.categoryTopicSort,
         settings: userSettings,
         query: req.query,
         tag: req.query.tag,
-        targetUid: targetUid,
+        targetUid,
     });
     if (!categoryData) {
         return next();

--- a/src/controllers/composer_original.js
+++ b/src/controllers/composer_original.js
@@ -22,8 +22,8 @@ exports.get = async function (req, res, callback) {
     };
 
     const data = await plugins.hooks.fire('filter:composer.build', {
-        req: req,
-        res: res,
+        req,
+        res,
         next: callback,
         templateData: {},
     });
@@ -49,7 +49,7 @@ exports.post = async function (req, res) {
     const { body } = req;
     const data = {
         uid: req.uid,
-        req: req,
+        req,
         timestamp: Date.now(),
         content: body.content,
         fromQueue: false,

--- a/src/controllers/errors.js
+++ b/src/controllers/errors.js
@@ -101,10 +101,10 @@ exports.handleErrors = async function handleErrors(err, req, res, next) { // esl
 async function getErrorHandlers(cases) {
     try {
         return await plugins.hooks.fire('filter:error.handle', {
-            cases: cases,
+            cases,
         });
     } catch (err) {
-        // Assume defaults
+    // Assume defaults
         winston.warn(`[errors/handle] Unable to retrieve plugin handlers for errors: ${err.message}`);
         return { cases };
     }

--- a/src/controllers/globalmods.js
+++ b/src/controllers/globalmods.js
@@ -20,12 +20,11 @@ globalModsController.ipBlacklist = async function (req, res, next) {
     ]);
     res.render('ip-blacklist', {
         title: '[[pages:ip-blacklist]]',
-        rules: rules,
+        rules,
         analytics: analyticsData,
         breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[pages:ip-blacklist]]' }]),
     });
 };
-
 
 globalModsController.registrationQueue = async function (req, res, next) {
     const isAdminOrGlobalMod = await user.isAdminOrGlobalMod(req.uid);

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -22,7 +22,7 @@ groupsController.list = async function (req, res) {
 
     res.render('groups/list', {
         groups: groupData,
-        allowGroupCreation: allowGroupCreation,
+        allowGroupCreation,
         nextStart: 15,
         title: '[[pages:groups]]',
         breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[pages:groups]]' }]),
@@ -80,8 +80,8 @@ groupsController.details = async function (req, res, next) {
         group: groupData,
         // posts rendered are the filtered posts
         posts: filteredPosts,
-        isAdmin: isAdmin,
-        isGlobalMod: isGlobalMod,
+        isAdmin,
+        isGlobalMod,
         allowPrivateGroups: meta.config.allowPrivateGroups,
         breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[pages:groups]]', url: '/groups' }, { text: groupData.displayName }]),
     });
@@ -116,8 +116,8 @@ groupsController.members = async function (req, res, next) {
 
     const pageCount = Math.max(1, Math.ceil(groupData.memberCount / usersPerPage));
     res.render('groups/members', {
-        users: users,
+        users,
         pagination: pagination.create(page, pageCount, req.query),
-        breadcrumbs: breadcrumbs,
+        breadcrumbs,
     });
 };

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -33,7 +33,7 @@ helpers.noScriptErrors = async function (req, res, error, httpStatus) {
     res.status(httpStatus).render(httpStatusString, {
         path: req.path,
         loggedIn: req.loggedIn,
-        error: error,
+        error,
         returnLink: true,
         title: `[[global:${httpStatusString}.title]]`,
     });
@@ -137,7 +137,7 @@ helpers.notAllowed = async function (req, res, error) {
                 res.status(403).json({
                     path: req.path.replace(/^\/api/, ''),
                     loggedIn: req.loggedIn,
-                    error: error,
+                    error,
                     title: '[[global:403.title]]',
                     bodyClass: middlewareHelpers.buildBodyClass(req, res),
                 });
@@ -184,20 +184,21 @@ helpers.redirect = function (res, url, permanent) {
 
 function prependRelativePath(url) {
     return url.startsWith('http://') || url.startsWith('https://') ?
-        url : relative_path + url;
+        url :
+        relative_path + url;
 }
 
 helpers.buildCategoryBreadcrumbs = async function (cid) {
     const breadcrumbs = [];
 
     while (parseInt(cid, 10)) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         const data = await categories.getCategoryFields(cid, ['name', 'slug', 'parentCid', 'disabled', 'isSection']);
         if (!data.disabled && !data.isSection) {
             breadcrumbs.unshift({
                 text: String(data.name),
                 url: `${relative_path}/category/${data.slug}`,
-                cid: cid,
+                cid,
             });
         }
         cid = data.parentCid;
@@ -291,12 +292,12 @@ helpers.getVisibleCategories = async function (params) {
     ]);
 
     const filtered = await plugins.hooks.fire('filter:helpers.getVisibleCategories', {
-        uid: uid,
-        allowed: allowed,
-        watchState: watchState,
-        categoriesData: categoriesData,
-        isModerator: isModerator,
-        isAdmin: isAdmin,
+        uid,
+        allowed,
+        watchState,
+        categoriesData,
+        isModerator,
+        isAdmin,
     });
     ({ allowed, watchState, categoriesData, isModerator, isAdmin } = filtered);
 
@@ -352,7 +353,7 @@ helpers.getSelectedCategory = async function (cids) {
         selectedCategories = null;
     }
     return {
-        selectedCids: selectedCids,
+        selectedCids,
         selectedCategory: selectedCategories,
     };
 };
@@ -419,8 +420,8 @@ helpers.getHomePageRoutes = async function (uid) {
         },
     ];
     const data = await plugins.hooks.fire('filter:homepage.get', {
-        uid: uid,
-        routes: routes,
+        uid,
+        routes,
     });
     return data.routes;
 };
@@ -487,7 +488,7 @@ helpers.formatApiResponse = async (statusCode, res, payload) => {
         }
         res.status(statusCode).json(returnPayload);
     } else if (!payload) {
-        // Non-2xx statusCode, generate predefined error
+    // Non-2xx statusCode, generate predefined error
         const returnPayload = await helpers.generateError(statusCode, null, res);
         res.status(statusCode).json(returnPayload);
     }

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -55,9 +55,9 @@ function pluginHook(req, res, next) {
     const hook = `action:homepage.get:${res.locals.homePageRoute}`;
 
     plugins.hooks.fire(hook, {
-        req: req,
-        res: res,
-        next: next,
+        req,
+        res,
+        next,
     });
 }
 

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -54,9 +54,9 @@ Controllers.reset = async function (req, res) {
 
     const renderReset = function (code, valid) {
         res.render('reset_code', {
-            valid: valid,
+            valid,
             displayExpiryNotice: req.session.passwordExpired,
-            code: code,
+            code,
             minimumPasswordLength: meta.config.minimumPasswordLength,
             minimumPasswordStrength: meta.config.minimumPasswordStrength,
             breadcrumbs: helpers.buildBreadcrumbs([
@@ -78,7 +78,7 @@ Controllers.reset = async function (req, res) {
     }
 
     if (req.session.reset_code) {
-        // Validate and save to local variable before removing from session
+    // Validate and save to local variable before removing from session
         const valid = await user.reset.validate(req.session.reset_code);
         renderReset(req.session.reset_code, valid);
         delete req.session.reset_code;
@@ -316,7 +316,6 @@ Controllers.manifest = async function (req, res) {
         });
     }
 
-
     if (meta.config['brand:maskableIcon']) {
         manifest.icons.push({
             src: `${nconf.get('relative_path')}/assets/uploads/system/maskableicon-orig.png`,
@@ -332,9 +331,9 @@ Controllers.manifest = async function (req, res) {
     }
 
     const data = await plugins.hooks.fire('filter:manifest.build', {
-        req: req,
-        res: res,
-        manifest: manifest,
+        req,
+        res,
+        manifest,
     });
     res.status(200).json(data.manifest);
 };

--- a/src/controllers/mods.js
+++ b/src/controllers/mods.js
@@ -82,8 +82,8 @@ modsController.flags.list = async function (req, res) {
 
     const [flagsData, analyticsData, selectData] = await Promise.all([
         flags.list({
-            filters: filters,
-            sort: sort,
+            filters,
+            sort,
             uid: req.uid,
             query: req.query,
         }),
@@ -95,8 +95,8 @@ modsController.flags.list = async function (req, res) {
         flags: flagsData.flags,
         analytics: analyticsData,
         selectedCategory: selectData.selectedCategory,
-        hasFilter: hasFilter,
-        filters: filters,
+        hasFilter,
+        filters,
         expanded: !!(filters.assignee || filters.reporterId || filters.targetUid),
         sort: sort || 'newest',
         title: '[[pages:flags]]',
@@ -160,7 +160,7 @@ modsController.postQueue = async function (req, res, next) {
     const page = parseInt(req.query.page, 10) || 1;
     const postsPerPage = 20;
 
-    let postData = await posts.getQueuedPosts({ id: id });
+    let postData = await posts.getQueuedPosts({ id });
     const [isAdmin, isGlobalMod, moderatedCids, categoriesData] = await Promise.all([
         user.isAdministrator(req.uid),
         user.isGlobalModerator(req.uid),
@@ -174,7 +174,7 @@ modsController.postQueue = async function (req, res, next) {
 
     ({ posts: postData } = await plugins.hooks.fire('filter:post-queue.get', {
         posts: postData,
-        req: req,
+        req,
     }));
 
     const pageCount = Math.max(1, Math.ceil(postData.length / postsPerPage));
@@ -184,12 +184,12 @@ modsController.postQueue = async function (req, res, next) {
     const crumbs = [{ text: '[[pages:post-queue]]', url: id ? '/post-queue' : undefined }];
     if (id && postData.length) {
         const text = postData[0].data.tid ? '[[post-queue:reply]]' : '[[post-queue:topic]]';
-        crumbs.push({ text: text });
+        crumbs.push({ text });
     }
     res.render('post-queue', {
         title: '[[pages:post-queue]]',
         posts: postData,
-        isAdmin: isAdmin,
+        isAdmin,
         canAccept: isAdmin || isGlobalMod || !!moderatedCids.length,
         ...categoriesData,
         allCategoriesUrl: `post-queue${helpers.buildQueryString(req.query, 'cid', '')}`,

--- a/src/controllers/popular.js
+++ b/src/controllers/popular.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const nconf = require('nconf');

--- a/src/controllers/recent.js
+++ b/src/controllers/recent.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const nconf = require('nconf');
@@ -46,13 +45,13 @@ recentController.getData = async function (req, url, sort) {
 
     const data = await topics.getSortedTopics({
         cids: cid,
-        tags: tags,
+        tags,
         uid: req.uid,
-        start: start,
-        stop: stop,
-        filter: filter,
-        term: term,
-        sort: sort,
+        start,
+        stop,
+        filter,
+        term,
+        sort,
         floatPinned: req.query.pinned,
         query: req.query,
     });
@@ -86,7 +85,7 @@ recentController.getData = async function (req, url, sort) {
 
     const pageCount = Math.max(1, Math.ceil(data.topicCount / settings.topicsPerPage));
     data.pagination = pagination.create(page, pageCount, req.query);
-    helpers.addLinkTags({ url: url, res: req.res, tags: data.pagination.rel });
+    helpers.addLinkTags({ url, res: req.res, tags: data.pagination.rel });
     return data;
 };
 

--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const validator = require('validator');
@@ -63,7 +62,7 @@ searchController.search = async function (req, res, next) {
         timeFilter: req.query.timeFilter,
         sortBy: req.query.sortBy || meta.config.searchDefaultSortBy || '',
         sortDirection: req.query.sortDirection,
-        page: page,
+        page,
         itemsPerPage: req.query.itemsPerPage,
         uid: req.uid,
         qs: req.query,

--- a/src/controllers/tags.js
+++ b/src/controllers/tags.js
@@ -21,7 +21,7 @@ tagsController.getTag = async function (req, res) {
 
     const templateData = {
         topics: [],
-        tag: tag,
+        tag,
         breadcrumbs: helpers.buildBreadcrumbs([{ text: '[[tags:tags]]', url: '/tags' }, { text: tag }]),
         title: `[[pages:tag, ${tag}]]`,
     };

--- a/src/controllers/top.js
+++ b/src/controllers/top.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const nconf = require('nconf');

--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const nconf = require('nconf');
@@ -27,11 +26,11 @@ unreadController.get = async function (req, res) {
     const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
     const stop = start + userSettings.topicsPerPage - 1;
     const data = await topics.getUnreadTopics({
-        cid: cid,
+        cid,
         uid: req.uid,
-        start: start,
-        stop: stop,
-        filter: filter,
+        start,
+        stop,
+        filter,
         query: req.query,
     });
 

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -155,7 +155,7 @@ uploadsController.uploadFile = async function (uid, uploadedFile) {
     if (plugins.hooks.hasListeners('filter:uploadFile')) {
         return await plugins.hooks.fire('filter:uploadFile', {
             file: uploadedFile,
-            uid: uid,
+            uid,
             folder: 'files',
         });
     }
@@ -192,7 +192,7 @@ async function saveFileToLocal(uid, folder, uploadedFile) {
     };
 
     await user.associateUpload(uid, upload.url.replace(`${nconf.get('upload_url')}/`, ''));
-    const data = await plugins.hooks.fire('filter:uploadStored', { uid: uid, uploadedFile: uploadedFile, storedFile: storedFile });
+    const data = await plugins.hooks.fire('filter:uploadStored', { uid, uploadedFile, storedFile });
     return data.storedFile;
 }
 

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -93,7 +93,7 @@ userController.exportProfile = async function (req, res, next) {
 
 // DEPRECATED; Remove in NodeBB v3.0.0
 function sendExport(filename, type, res, next) {
-    winston.warn(`[users/export] Access via page API is deprecated, use GET /api/v3/users/:uid/exports/:type instead.`);
+    winston.warn('[users/export] Access via page API is deprecated, use GET /api/v3/users/:uid/exports/:type instead.');
 
     res.sendFile(filename, {
         root: path.join(__dirname, '../../build/export'),

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -141,8 +141,8 @@ usersController.getUsers = async function (set, uid, query) {
         title: setToData[set].title || '[[pages:users/latest]]',
         breadcrumbs: helpers.buildBreadcrumbs(breadcrumbs),
         isAdminOrGlobalMod: isAdmin || isGlobalMod,
-        isAdmin: isAdmin,
-        isGlobalMod: isGlobalMod,
+        isAdmin,
+        isGlobalMod,
         displayUserSearch: canSearch,
         [`section_${query.section || 'joindate'}`]: true,
     };
@@ -185,7 +185,7 @@ usersController.getUsersAndCount = async function (set, uid, start, stop) {
     ]);
     return {
         users: usersData.filter(user => user && parseInt(user.uid, 10)),
-        count: count,
+        count,
     };
 };
 

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -9,7 +9,7 @@ const helpers = require('../helpers');
 const Categories = module.exports;
 
 const hasAdminPrivilege = async (uid) => {
-    const ok = await privileges.admin.can(`admin:categories`, uid);
+    const ok = await privileges.admin.can('admin:categories', uid);
     if (!ok) {
         throw new Error('[[error:no-privileges]]');
     }

--- a/src/controllers/write/users.js
+++ b/src/controllers/write/users.js
@@ -180,7 +180,7 @@ Users.revokeSession = async (req, res) => {
     const sids = await db.getSortedSetRange(`uid:${req.params.uid}:sessions`, 0, -1);
     let _id;
     for (const sid of sids) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         const sessionObj = await getSessionAsync(sid);
         if (sessionObj && sessionObj.meta && sessionObj.meta.uuid === req.params.uuid) {
             _id = sid;
@@ -229,7 +229,7 @@ Users.invite = async (req, res) => {
     const emailsArr = emails.split(',').map(email => email.trim()).filter(Boolean);
 
     for (const email of emailsArr) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         let invites = 0;
         if (max) {
             invites = await user.getInvitesNumber(req.uid);

--- a/src/coverPhoto.js
+++ b/src/coverPhoto.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const nconf = require('nconf');
 const meta = require('./meta');
 

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -27,7 +27,7 @@ primaryDB.initSessionStore = async function () {
     if (nconf.get('session_store')) {
         sessionStoreDB = require(`./${sessionStoreConfig.name}`);
     } else if (nconf.get('redis')) {
-        // if redis is specified, use it as session store over others
+    // if redis is specified, use it as session store over others
         sessionStoreDB = require('./redis');
     }
 

--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -1,6 +1,4 @@
-
 'use strict';
-
 
 const winston = require('winston');
 const nconf = require('nconf');

--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -84,7 +84,7 @@ module.exports = function (module) {
 
         let result = [];
         async function doQuery(_key, fields, skip, limit) {
-            return await module.client.collection('objects').find({ ...query, ...{ _key: _key } }, { projection: fields })
+            return await module.client.collection('objects').find({ ...query, ...{ _key } }, { projection: fields })
                 .sort({ score: sort })
                 .skip(skip)
                 .limit(limit)
@@ -210,7 +210,7 @@ module.exports = function (module) {
                 },
                 {
                     _key: key,
-                    score: score,
+                    score,
                     value: reverse ? { $gt: value } : { $lt: value },
                 },
             ],
@@ -264,7 +264,7 @@ module.exports = function (module) {
             return null;
         }
         value = helpers.valueToString(value);
-        const result = await module.client.collection('objects').findOne({ _key: key, value: value }, { projection: { _id: 0, _key: 0, value: 0 } });
+        const result = await module.client.collection('objects').findOne({ _key: key, value }, { projection: { _id: 0, _key: 0, value: 0 } });
         return result ? result.score : null;
     };
 
@@ -273,7 +273,7 @@ module.exports = function (module) {
             return [];
         }
         value = helpers.valueToString(value);
-        const result = await module.client.collection('objects').find({ _key: { $in: keys }, value: value }, { projection: { _id: 0, value: 0 } }).toArray();
+        const result = await module.client.collection('objects').find({ _key: { $in: keys }, value }, { projection: { _id: 0, value: 0 } }).toArray();
         const map = {};
         result.forEach((item) => {
             if (item) {
@@ -310,7 +310,7 @@ module.exports = function (module) {
         }
         value = helpers.valueToString(value);
         const result = await module.client.collection('objects').findOne({
-            _key: key, value: value,
+            _key: key, value,
         }, {
             projection: { _id: 0, value: 1 },
         });
@@ -347,7 +347,7 @@ module.exports = function (module) {
         }
         value = helpers.valueToString(value);
         const results = await module.client.collection('objects').find({
-            _key: { $in: keys }, value: value,
+            _key: { $in: keys }, value,
         }, {
             projection: { _id: 0, _key: 1, value: 1 },
         }).toArray();
@@ -378,7 +378,7 @@ module.exports = function (module) {
         }
         const data = await module.client.collection('objects').find({
             _key: arrayOfKeys ? { $in: keys } : keys[0],
-        }, { projection: projection }).toArray();
+        }, { projection }).toArray();
 
         if (!arrayOfKeys) {
             return [data.map(item => item.value)];
@@ -403,7 +403,7 @@ module.exports = function (module) {
         try {
             const result = await module.client.collection('objects').findOneAndUpdate({
                 _key: key,
-                value: value,
+                value,
             }, {
                 $inc: data,
             }, {

--- a/src/database/mongo/sorted/add.js
+++ b/src/database/mongo/sorted/add.js
@@ -17,7 +17,7 @@ module.exports = function (module) {
         value = helpers.valueToString(value);
 
         try {
-            await module.client.collection('objects').updateOne({ _key: key, value: value }, { $set: { score: parseFloat(score) } }, { upsert: true });
+            await module.client.collection('objects').updateOne({ _key: key, value }, { $set: { score: parseFloat(score) } }, { upsert: true });
         } catch (err) {
             if (err && err.message.startsWith('E11000 duplicate key error')) {
                 return await module.sortedSetAdd(key, score, value);
@@ -66,7 +66,7 @@ module.exports = function (module) {
         const bulk = module.client.collection('objects').initializeUnorderedBulkOp();
         for (let i = 0; i < keys.length; i += 1) {
             bulk
-                .find({ _key: keys[i], value: value })
+                .find({ _key: keys[i], value })
                 .upsert()
                 .updateOne({ $set: { score: parseFloat(isArrayOfScores ? scores[i] : scores) } });
         }

--- a/src/database/mongo/sorted/intersect.js
+++ b/src/database/mongo/sorted/intersect.js
@@ -37,8 +37,8 @@ module.exports = function (module) {
         const index = counts.indexOf(minCount);
         const smallestSet = sets[index];
         return {
-            minCount: minCount,
-            smallestSet: smallestSet,
+            minCount,
+            smallestSet,
         };
     }
 

--- a/src/database/mongo/sorted/remove.js
+++ b/src/database/mongo/sorted/remove.js
@@ -30,7 +30,7 @@ module.exports = function (module) {
         }
         value = helpers.valueToString(value);
 
-        await module.client.collection('objects').deleteMany({ _key: { $in: keys }, value: value });
+        await module.client.collection('objects').deleteMany({ _key: { $in: keys }, value });
     };
 
     module.sortedSetsRemoveRangeByScore = async function (keys, min, max) {

--- a/src/database/postgres.js
+++ b/src/database/postgres.js
@@ -62,7 +62,6 @@ postgresModule.init = async function () {
     }
 };
 
-
 async function checkUpgrade(client) {
     const res = await client.query(`
 SELECT EXISTS(SELECT *
@@ -84,7 +83,7 @@ SELECT EXISTS(SELECT *
         return;
     }
 
-    await client.query(`BEGIN`);
+    await client.query('BEGIN');
     try {
         if (!res.rows[0].b) {
             await client.query(`
@@ -257,8 +256,8 @@ SELECT "data"->>'_key',
           FROM jsonb_object_keys("data" - 'expireAt')) = 2
    AND (("data" ? 'value')
      OR ("data" ? 'data'))`);
-                await client.query(`DROP TABLE "objects" CASCADE`);
-                await client.query(`DROP FUNCTION "fun__objects__expireAt"() CASCADE`);
+                await client.query('DROP TABLE "objects" CASCADE');
+                await client.query('DROP FUNCTION "fun__objects__expireAt"() CASCADE');
             }
             await client.query(`
 CREATE VIEW "legacy_object_live" AS
@@ -283,10 +282,10 @@ STRICT
 PARALLEL SAFE`);
         }
     } catch (ex) {
-        await client.query(`ROLLBACK`);
+        await client.query('ROLLBACK');
         throw ex;
     }
-    await client.query(`COMMIT`);
+    await client.query('COMMIT');
 }
 
 postgresModule.createSessionStore = async function (options) {
@@ -335,8 +334,8 @@ postgresModule.createIndices = function (callback) {
 
     winston.info('[database] Checking database indices.');
     async.series([
-        async.apply(query, `CREATE INDEX IF NOT EXISTS "idx__legacy_zset__key__score" ON "legacy_zset"("_key" ASC, "score" DESC)`),
-        async.apply(query, `CREATE INDEX IF NOT EXISTS "idx__legacy_object__expireAt" ON "legacy_object"("expireAt" ASC)`),
+        async.apply(query, 'CREATE INDEX IF NOT EXISTS "idx__legacy_zset__key__score" ON "legacy_zset"("_key" ASC, "score" DESC)'),
+        async.apply(query, 'CREATE INDEX IF NOT EXISTS "idx__legacy_object__expireAt" ON "legacy_object"("expireAt" ASC)'),
     ], (err) => {
         if (err) {
             winston.error(`Error creating index ${err.message}`);

--- a/src/database/postgres/hash.js
+++ b/src/database/postgres/hash.js
@@ -350,25 +350,27 @@ SELECT (h."data" ? $2::TEXT AND h."data"->>$2::TEXT IS NOT NULL) b
                 await helpers.ensureLegacyObjectType(client, key, 'hash');
             }
 
-            const res = await client.query(Array.isArray(key) ? {
-                name: 'incrObjectFieldByMulti',
-                text: `
+            const res = await client.query(Array.isArray(key) ?
+                {
+                    name: 'incrObjectFieldByMulti',
+                    text: `
 INSERT INTO "legacy_hash" ("_key", "data")
 SELECT UNNEST($1::TEXT[]), jsonb_build_object($2::TEXT, $3::NUMERIC)
 ON CONFLICT ("_key")
 DO UPDATE SET "data" = jsonb_set("legacy_hash"."data", ARRAY[$2::TEXT], to_jsonb(COALESCE(("legacy_hash"."data"->>$2::TEXT)::NUMERIC, 0) + $3::NUMERIC))
 RETURNING ("data"->>$2::TEXT)::NUMERIC v`,
-                values: [key, field, value],
-            } : {
-                name: 'incrObjectFieldBy',
-                text: `
+                    values: [key, field, value],
+                } :
+                {
+                    name: 'incrObjectFieldBy',
+                    text: `
 INSERT INTO "legacy_hash" ("_key", "data")
 VALUES ($1::TEXT, jsonb_build_object($2::TEXT, $3::NUMERIC))
 ON CONFLICT ("_key")
 DO UPDATE SET "data" = jsonb_set("legacy_hash"."data", ARRAY[$2::TEXT], to_jsonb(COALESCE(("legacy_hash"."data"->>$2::TEXT)::NUMERIC, 0) + $3::NUMERIC))
 RETURNING ("data"->>$2::TEXT)::NUMERIC v`,
-                values: [key, field, value],
-            });
+                    values: [key, field, value],
+                });
             return Array.isArray(key) ? res.rows.map(r => parseFloat(r.v)) : parseFloat(res.rows[0].v);
         });
     };

--- a/src/database/postgres/list.js
+++ b/src/database/postgres/list.js
@@ -100,9 +100,10 @@ UPDATE "legacy_list" l
 
         stop += 1;
 
-        await module.pool.query(stop > 0 ? {
-            name: 'listTrim',
-            text: `
+        await module.pool.query(stop > 0 ?
+            {
+                name: 'listTrim',
+                text: `
 UPDATE "legacy_list" l
    SET "array" = ARRAY(SELECT m.m
                          FROM UNNEST(l."array") WITH ORDINALITY m(m, i)
@@ -113,10 +114,11 @@ UPDATE "legacy_list" l
  WHERE o."_key" = l."_key"
    AND o."type" = l."type"
    AND o."_key" = $1::TEXT`,
-            values: [key, start, stop],
-        } : {
-            name: 'listTrimBack',
-            text: `
+                values: [key, start, stop],
+            } :
+            {
+                name: 'listTrimBack',
+                text: `
 UPDATE "legacy_list" l
    SET "array" = ARRAY(SELECT m.m
                          FROM UNNEST(l."array") WITH ORDINALITY m(m, i)
@@ -127,8 +129,8 @@ UPDATE "legacy_list" l
  WHERE o."_key" = l."_key"
    AND o."type" = l."type"
    AND o."_key" = $1::TEXT`,
-            values: [key, start, stop],
-        });
+                values: [key, start, stop],
+            });
     };
 
     module.getListRange = async function (key, start, stop) {
@@ -138,9 +140,10 @@ UPDATE "legacy_list" l
 
         stop += 1;
 
-        const res = await module.pool.query(stop > 0 ? {
-            name: 'getListRange',
-            text: `
+        const res = await module.pool.query(stop > 0 ?
+            {
+                name: 'getListRange',
+                text: `
 SELECT ARRAY(SELECT m.m
                FROM UNNEST(l."array") WITH ORDINALITY m(m, i)
               ORDER BY m.i ASC
@@ -151,10 +154,11 @@ SELECT ARRAY(SELECT m.m
          ON o."_key" = l."_key"
         AND o."type" = l."type"
       WHERE o."_key" = $1::TEXT`,
-            values: [key, start, stop],
-        } : {
-            name: 'getListRangeBack',
-            text: `
+                values: [key, start, stop],
+            } :
+            {
+                name: 'getListRangeBack',
+                text: `
 SELECT ARRAY(SELECT m.m
                FROM UNNEST(l."array") WITH ORDINALITY m(m, i)
               ORDER BY m.i ASC
@@ -165,8 +169,8 @@ SELECT ARRAY(SELECT m.m
          ON o."_key" = l."_key"
         AND o."type" = l."type"
  WHERE o."_key" = $1::TEXT`,
-            values: [key, start, stop],
-        });
+                values: [key, start, stop],
+            });
 
         return res.rows.length ? res.rows[0].l : [];
     };

--- a/src/database/postgres/main.js
+++ b/src/database/postgres/main.js
@@ -4,12 +4,12 @@ module.exports = function (module) {
     const helpers = require('./helpers');
 
     module.flushdb = async function () {
-        await module.pool.query(`DROP SCHEMA "public" CASCADE`);
-        await module.pool.query(`CREATE SCHEMA "public"`);
+        await module.pool.query('DROP SCHEMA "public" CASCADE');
+        await module.pool.query('CREATE SCHEMA "public"');
     };
 
     module.emptydb = async function () {
-        await module.pool.query(`DELETE FROM "legacy_object"`);
+        await module.pool.query('DELETE FROM "legacy_object"');
     };
 
     module.exists = async function (key) {

--- a/src/database/postgres/sorted.js
+++ b/src/database/postgres/sorted.js
@@ -499,7 +499,7 @@ RETURNING "score" s`,
     };
 
     module.sortedSetIncrByBulk = async function (data) {
-        // TODO: perf single query?
+    // TODO: perf single query?
         return await Promise.all(data.map(item => module.sortedSetIncrBy(item[0], item[1], item[2])));
     };
 
@@ -571,7 +571,7 @@ DELETE FROM "legacy_zset" z
     function buildLexQuery(key, min, max) {
         const q = {
             suffix: '',
-            where: `o."_key" = $1::TEXT`,
+            where: 'o."_key" = $1::TEXT',
             values: [key],
         };
 

--- a/src/database/postgres/sorted/add.js
+++ b/src/database/postgres/sorted/add.js
@@ -85,12 +85,14 @@ DO UPDATE SET "score" = EXCLUDED."score"`,
             await helpers.ensureLegacyObjectsType(client, keys, 'zset');
             await client.query({
                 name: isArrayOfScores ? 'sortedSetsAddScores' : 'sortedSetsAdd',
-                text: isArrayOfScores ? `
+                text: isArrayOfScores ?
+                    `
 INSERT INTO "legacy_zset" ("_key", "value", "score")
 SELECT k, $2::TEXT, s
 FROM UNNEST($1::TEXT[], $3::NUMERIC[]) vs(k, s)
 ON CONFLICT ("_key", "value")
-    DO UPDATE SET "score" = EXCLUDED."score"` : `
+    DO UPDATE SET "score" = EXCLUDED."score"` :
+                    `
 INSERT INTO "legacy_zset" ("_key", "value", "score")
     SELECT k, $2::TEXT, $3::NUMERIC
         FROM UNNEST($1::TEXT[]) k

--- a/src/database/postgres/transaction.js
+++ b/src/database/postgres/transaction.js
@@ -4,14 +4,14 @@ module.exports = function (module) {
     module.transaction = async function (perform, txClient) {
         let res;
         if (txClient) {
-            await txClient.query(`SAVEPOINT nodebb_subtx`);
+            await txClient.query('SAVEPOINT nodebb_subtx');
             try {
                 res = await perform(txClient);
             } catch (err) {
-                await txClient.query(`ROLLBACK TO SAVEPOINT nodebb_subtx`);
+                await txClient.query('ROLLBACK TO SAVEPOINT nodebb_subtx');
                 throw err;
             }
-            await txClient.query(`RELEASE SAVEPOINT nodebb_subtx`);
+            await txClient.query('RELEASE SAVEPOINT nodebb_subtx');
             return res;
         }
         // see https://node-postgres.com/features/transactions#a-pooled-client-with-async-await

--- a/src/database/redis.js
+++ b/src/database/redis.js
@@ -33,7 +33,6 @@ redisModule.questions = [
     },
 ];
 
-
 redisModule.init = async function () {
     redisModule.client = await connection.connect(nconf.get('redis'));
 };
@@ -43,7 +42,7 @@ redisModule.createSessionStore = async function (options) {
     const sessionStore = require('connect-redis')(session);
     const client = await connection.connect(options);
     const store = new sessionStore({
-        client: client,
+        client,
         ttl: meta.getSessionTTLSeconds(),
     });
     return store;

--- a/src/database/redis/pubsub.js
+++ b/src/database/redis/pubsub.js
@@ -38,7 +38,7 @@ const PubSub = function () {
 util.inherits(PubSub, EventEmitter);
 
 PubSub.prototype.publish = function (event, data) {
-    const payload = JSON.stringify({ event: event, data: data });
+    const payload = JSON.stringify({ event, data });
     if (this.pubClient) {
         this.pubClient.publish(channelName, payload);
     } else {

--- a/src/database/redis/sorted.js
+++ b/src/database/redis/sorted.js
@@ -308,7 +308,7 @@ module.exports = function (module) {
                     seen[value] = 1;
 
                     if (params.withScores) {
-                        returnData.push({ value: value, score: parseFloat(data[i + 1]) });
+                        returnData.push({ value, score: parseFloat(data[i + 1]) });
                     } else {
                         returnData.push(value);
                     }

--- a/src/database/redis/sorted/intersect.js
+++ b/src/database/redis/sorted/intersect.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 module.exports = function (module) {

--- a/src/database/redis/sorted/remove.js
+++ b/src/database/redis/sorted/remove.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 module.exports = function (module) {

--- a/src/database/redis/sorted/union.js
+++ b/src/database/redis/sorted/union.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 module.exports = function (module) {

--- a/src/emailer.js
+++ b/src/emailer.js
@@ -61,7 +61,7 @@ const getHostname = () => {
 
 const buildCustomTemplates = async (config) => {
     try {
-        // If the new config contains any email override values, re-compile those templates
+    // If the new config contains any email override values, re-compile those templates
         const toBuild = Object
             .keys(config)
             .filter(prop => prop.startsWith('email:custom:'))
@@ -105,10 +105,10 @@ Emailer.getTemplates = async (config) => {
         const original = await fs.promises.readFile(email, 'utf8');
 
         return {
-            path: path,
+            path,
             fullpath: email,
             text: config[`email:custom:${path}`] || original,
-            original: original,
+            original,
             isCustom: !!config[`email:custom:${path}`],
         };
     }));
@@ -187,8 +187,8 @@ Emailer.registerApp = (expressApp) => {
     prevConfig = { ...meta.config };
 
     pubsub.on('config:update', (config) => {
-        // config object only contains properties for the specific acp settings page
-        // not the entire meta.config object
+    // config object only contains properties for the specific acp settings page
+    // not the entire meta.config object
         if (config) {
             // Update default payload if new logo is uploaded
             if (config.hasOwnProperty('brand:emailLogo')) {
@@ -257,8 +257,8 @@ Emailer.send = async (template, uid, params) => {
 
     const result = await Plugins.hooks.fire('filter:email.cancel', {
         cancel: false, // set to true in plugin to cancel sending email
-        template: template,
-        params: params,
+        template,
+        params,
     });
 
     if (result.cancel) {
@@ -273,7 +273,7 @@ Emailer.sendToEmail = async (template, email, language, params) => {
 
     // Digests and notifications can be one-click unsubbed
     let payload = {
-        template: template,
+        template,
         uid: params.uid,
     };
 
@@ -296,10 +296,10 @@ Emailer.sendToEmail = async (template, email, language, params) => {
     }
 
     const result = await Plugins.hooks.fire('filter:email.params', {
-        template: template,
-        email: email,
+        template,
+        email,
         language: lang,
-        params: params,
+        params,
     });
 
     template = result.template;
@@ -317,11 +317,11 @@ Emailer.sendToEmail = async (template, email, language, params) => {
         from: meta.config['email:from'] || `no-reply@${getHostname()}`,
         from_name: meta.config['email:from_name'] || 'NodeBB',
         subject: `[${meta.config.title}] ${_.unescape(subject)}`,
-        html: html,
+        html,
         plaintext: htmlToText(html, {
             tags: { img: { format: 'skip' } },
         }),
-        template: template,
+        template,
         uid: params.uid,
         pid: params.pid,
         fromUid: params.fromUid,

--- a/src/events.js
+++ b/src/events.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const validator = require('validator');
@@ -94,7 +93,7 @@ events.log = async function (data) {
         ], data.timestamp, eid),
         db.setObject(`event:${eid}`, data),
     ]);
-    plugins.hooks.fire('action:events.log', { data: data });
+    plugins.hooks.fire('action:events.log', { data });
 };
 
 events.getEvents = async function (filter, start, stop, from, to) {

--- a/src/flags.js
+++ b/src/flags.js
@@ -89,7 +89,7 @@ Flags.init = async function () {
         },
         states: Flags._states,
         helpers: {
-            prepareSets: prepareSets,
+            prepareSets,
         },
     };
 
@@ -155,7 +155,7 @@ Flags.getFlagIdsWithFilters = async function ({ filters, uid, query }) {
     if (sets.length === 1) {
         flagIds = await db.getSortedSetRevRange(sets[0], 0, -1);
     } else if (sets.length > 1) {
-        flagIds = await db.getSortedSetRevIntersect({ sets: sets, start: 0, stop: -1, aggregate: 'MAX' });
+        flagIds = await db.getSortedSetRevIntersect({ sets, start: 0, stop: -1, aggregate: 'MAX' });
     }
 
     if (orSets.length) {
@@ -216,7 +216,7 @@ Flags.list = async function (data) {
     }));
 
     const payload = await plugins.hooks.fire('filter:flags.list', {
-        flags: flags,
+        flags,
         page: filters.page,
         uid: data.uid,
     });
@@ -224,7 +224,7 @@ Flags.list = async function (data) {
     return {
         flags: payload.flags,
         page: payload.page,
-        pageCount: pageCount,
+        pageCount,
     };
 };
 
@@ -394,7 +394,7 @@ Flags.create = async function (type, id, uid, reason, timestamp, forceFlag = fal
         doHistoryAppend = true;
     }
     const [flagExists, targetExists,, targetFlagged, targetUid, targetCid] = await Promise.all([
-        // Sanity checks
+    // Sanity checks
         Flags.exists(type, id, uid),
         Flags.targetExists(type, id),
         Flags.canFlag(type, id, uid, forceFlag),
@@ -426,10 +426,10 @@ Flags.create = async function (type, id, uid, reason, timestamp, forceFlag = fal
 
     batched.push(
         db.setObject(`flag:${flagId}`, {
-            flagId: flagId,
-            type: type,
+            flagId,
+            type,
             targetId: id,
-            targetUid: targetUid,
+            targetUid,
             datetime: timestamp,
         }),
         Flags.addReport(flagId, type, id, uid, reason, timestamp),
@@ -488,7 +488,7 @@ Flags.purge = async function (flagIds) {
     flagData.forEach((flagObj, i) => {
         if (Array.isArray(allReporterUids[i])) {
             allReporterUids[i].forEach((uid) => {
-                removeReporters.push([`flags:hash`, [flagObj.type, flagObj.targetId, uid].join(':')]);
+                removeReporters.push(['flags:hash', [flagObj.type, flagObj.targetId, uid].join(':')]);
                 removeReporters.push([`flags:byReporter:${uid}`, flagObj.flagId]);
             });
         }
@@ -717,7 +717,7 @@ Flags.update = async function (flagId, uid, changeset) {
     tasks.push(Flags.appendHistory(flagId, uid, changeset));
     await Promise.all(tasks);
 
-    plugins.hooks.fire('action:flags.update', { flagId: flagId, changeset: changeset, uid: uid });
+    plugins.hooks.fire('action:flags.update', { flagId, changeset, uid });
 };
 
 Flags.resolveFlag = async function (type, id, uid) {
@@ -806,7 +806,7 @@ Flags.appendNote = async function (flagId, uid, note, datetime) {
     await db.sortedSetAdd(`flag:${flagId}:notes`, datetime, payload);
     await Flags.appendHistory(flagId, uid, {
         notes: null,
-        datetime: datetime,
+        datetime,
     });
 };
 

--- a/src/groups/cover.js
+++ b/src/groups/cover.js
@@ -36,7 +36,7 @@ module.exports = function (Groups) {
             const filename = `groupCover-${data.groupName}${path.extname(tempPath)}`;
             const uploadData = await image.uploadImage(filename, 'files', {
                 path: tempPath,
-                uid: uid,
+                uid,
                 name: 'groupCover',
             });
             const { url } = uploadData;
@@ -48,7 +48,7 @@ module.exports = function (Groups) {
             });
             const thumbUploadData = await image.uploadImage(`groupCoverThumb-${data.groupName}${path.extname(tempPath)}`, 'files', {
                 path: tempPath,
-                uid: uid,
+                uid,
                 name: 'groupCover',
             });
             await Groups.setGroupField(data.groupName, 'cover:thumb:url', thumbUploadData.url);
@@ -57,7 +57,7 @@ module.exports = function (Groups) {
                 await Groups.updateCoverPosition(data.groupName, data.position);
             }
 
-            return { url: url };
+            return { url };
         } finally {
             file.delete(tempPath);
         }

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -32,15 +32,15 @@ module.exports = function (Groups) {
             userTitle: data.userTitle || data.name,
             userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
             description: data.description || '',
-            memberCount: memberCount,
+            memberCount,
             hidden: isHidden ? 1 : 0,
             system: isSystem ? 1 : 0,
             private: isPrivate ? 1 : 0,
-            disableJoinRequests: disableJoinRequests,
-            disableLeave: disableLeave,
+            disableJoinRequests,
+            disableLeave,
         };
 
-        await plugins.hooks.fire('filter:group.create', { group: groupData, data: data });
+        await plugins.hooks.fire('filter:group.create', { group: groupData, data });
 
         await db.sortedSetAdd('groups:createtime', groupData.createtime, groupData.name);
         await db.setObject(`group:${groupData.name}`, groupData);

--- a/src/groups/data.js
+++ b/src/groups/data.js
@@ -61,7 +61,7 @@ module.exports = function (Groups) {
 
     Groups.setGroupField = async function (groupName, field, value) {
         await db.setObjectField(`group:${groupName}`, field, value);
-        plugins.hooks.fire('action:group.set', { field: field, value: value, type: 'set' });
+        plugins.hooks.fire('action:group.set', { field, value, type: 'set' });
     };
 };
 

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -191,9 +191,9 @@ Groups.getOwnersAndMembers = async function (groupName, uid, start, stop) {
     returnUsers = countToReturn > 0 ? returnUsers.slice(0, countToReturn) : returnUsers;
     const result = await plugins.hooks.fire('filter:group.getOwnersAndMembers', {
         users: returnUsers,
-        uid: uid,
-        start: start,
-        stop: stop,
+        uid,
+        start,
+        stop,
     });
     return result.users;
 };

--- a/src/groups/invite.js
+++ b/src/groups/invite.js
@@ -85,8 +85,8 @@ module.exports = function (Groups) {
         await db.setAdd(set, uids);
         const hookName = type === 'invite' ? 'inviteMember' : 'requestMembership';
         plugins.hooks.fire(`action:group.${hookName}`, {
-            groupName: groupName,
-            uids: uids,
+            groupName,
+            uids,
         });
         return uids;
     }

--- a/src/groups/join.js
+++ b/src/groups/join.js
@@ -65,7 +65,7 @@ module.exports = function (Groups) {
 
         plugins.hooks.fire('action:group.join', {
             groupNames: groupsToJoin,
-            uid: uid,
+            uid,
         });
     };
 

--- a/src/groups/leave.js
+++ b/src/groups/leave.js
@@ -57,7 +57,7 @@ module.exports = function (Groups) {
 
         plugins.hooks.fire('action:group.leave', {
             groupNames: groupsToLeave,
-            uid: uid,
+            uid,
         });
     };
 

--- a/src/groups/ownership.js
+++ b/src/groups/ownership.js
@@ -23,17 +23,17 @@ module.exports = function (Groups) {
 
     Groups.ownership.grant = async function (toUid, groupName) {
         await db.setAdd(`group:${groupName}:owners`, toUid);
-        plugins.hooks.fire('action:group.grantOwnership', { uid: toUid, groupName: groupName });
+        plugins.hooks.fire('action:group.grantOwnership', { uid: toUid, groupName });
     };
 
     Groups.ownership.rescind = async function (toUid, groupName) {
-        // If the owners set only contains one member (and toUid is that member), error out!
+    // If the owners set only contains one member (and toUid is that member), error out!
         const numOwners = await db.setCount(`group:${groupName}:owners`);
         const isOwner = await db.isSortedSetMember(`group:${groupName}:owners`);
         if (numOwners <= 1 && isOwner) {
             throw new Error('[[error:group-needs-owner]]');
         }
         await db.setRemove(`group:${groupName}:owners`, toUid);
-        plugins.hooks.fire('action:group.rescindOwnership', { uid: toUid, groupName: groupName });
+        plugins.hooks.fire('action:group.rescindOwnership', { uid: toUid, groupName });
     };
 };

--- a/src/groups/search.js
+++ b/src/groups/search.js
@@ -53,7 +53,7 @@ module.exports = function (Groups) {
     Groups.searchMembers = async function (data) {
         if (!data.query) {
             const users = await Groups.getOwnersAndMembers(data.groupName, data.uid, 0, 19);
-            return { users: users };
+            return { users };
         }
 
         const results = await user.search({

--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -11,7 +11,6 @@ const batch = require('../batch');
 const meta = require('../meta');
 const cache = require('../cache');
 
-
 module.exports = function (Groups) {
     Groups.update = async function (groupName, values) {
         const exists = await db.exists(`group:${groupName}`);
@@ -20,8 +19,8 @@ module.exports = function (Groups) {
         }
 
         ({ values } = await plugins.hooks.fire('filter:group.update', {
-            groupName: groupName,
-            values: values,
+            groupName,
+            values,
         }));
 
         // Cast some values as bool (if not boolean already)
@@ -86,7 +85,7 @@ module.exports = function (Groups) {
 
         plugins.hooks.fire('action:group.update', {
             name: groupName,
-            values: values,
+            values,
         });
     };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,5 +3,5 @@
 module.exports = require('../public/src/modules/helpers.common')(
     require('./utils'),
     require('benchpressjs'),
-    require('nconf').get('relative_path'),
+    require('nconf').get('relative_path')
 );

--- a/src/image.js
+++ b/src/image.js
@@ -15,7 +15,7 @@ const image = module.exports;
 function requireSharp() {
     const sharp = require('sharp');
     if (os.platform() === 'win32') {
-        // https://github.com/lovell/sharp/issues/1259
+    // https://github.com/lovell/sharp/issues/1259
         sharp.cache(false);
     }
     return sharp;
@@ -80,7 +80,7 @@ image.resizeImage = async function (data) {
 image.normalise = async function (path) {
     if (plugins.hooks.hasListeners('filter:image.normalise')) {
         await plugins.hooks.fire('filter:image.normalise', {
-            path: path,
+            path,
         });
     } else {
         const sharp = requireSharp();
@@ -93,7 +93,7 @@ image.size = async function (path) {
     let imageData;
     if (plugins.hooks.hasListeners('filter:image.size')) {
         imageData = await plugins.hooks.fire('filter:image.size', {
-            path: path,
+            path,
         });
     } else {
         const sharp = requireSharp();
@@ -109,7 +109,7 @@ image.stripEXIF = async function (path) {
     try {
         if (plugins.hooks.hasListeners('filter:image.stripEXIF')) {
             await plugins.hooks.fire('filter:image.stripEXIF', {
-                path: path,
+                path,
             });
             return;
         }
@@ -167,7 +167,7 @@ image.uploadImage = async function (filename, folder, imageData) {
         return await plugins.hooks.fire('filter:uploadImage', {
             image: imageData,
             uid: imageData.uid,
-            folder: folder,
+            folder,
         });
     }
     await image.isFileTypeAllowed(imageData.path);

--- a/src/install.js
+++ b/src/install.js
@@ -158,7 +158,7 @@ async function setupConfig() {
     let config = {};
 
     if (install.values) {
-        // Use provided values, fall back to defaults
+    // Use provided values, fall back to defaults
         const redisQuestions = require('./database/redis').questions;
         const mongoQuestions = require('./database/mongo').questions;
         const postgresQuestions = require('./database/postgres').questions;
@@ -262,7 +262,7 @@ async function createDefaultUserGroups() {
     const groups = require('./groups');
     async function createGroup(name) {
         await groups.create({
-            name: name,
+            name,
             hidden: 1,
             private: 1,
             system: 1,
@@ -367,7 +367,7 @@ async function createAdmin() {
     }
 
     async function retryPassword(originalResults) {
-        // Ask only the password questions
+    // Ask only the password questions
         const results = await prompt.get(passwordQuestions);
 
         // Update the original data with newly collected password
@@ -450,7 +450,7 @@ async function createCategories() {
         await fs.promises.readFile(path.join(__dirname, '../', 'install/data/categories.json'), 'utf8')
     );
     for (const categoryData of default_categories) {
-        // eslint-disable-next-line no-await-in-loop
+    // eslint-disable-next-line no-await-in-loop
         await Categories.create(categoryData);
     }
 }
@@ -482,7 +482,7 @@ async function createWelcomePost() {
             uid: 1,
             cid: 2,
             title: 'Welcome to your NodeBB!',
-            content: content,
+            content,
         });
     }
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -13,7 +13,6 @@ const morgan = require('morgan');
 const file = require('./file');
 const meta = require('./meta');
 
-
 const opts = {
     /*
      * state used by Logger
@@ -205,7 +204,7 @@ Logger.io_one = function (socket, uid) {
     }
 
     if (socket && meta.config.loggerIOStatus > 0) {
-        // courtesy of: http://stackoverflow.com/a/9674248
+    // courtesy of: http://stackoverflow.com/a/9674248
         socket.oEmit = socket.emit;
         const { emit } = socket;
         socket.emit = override(emit, 'emit', 'Logger.io_one: emit.apply: Failed');

--- a/src/messaging/create.js
+++ b/src/messaging/create.js
@@ -38,7 +38,7 @@ module.exports = function (Messaging) {
         const timestamp = data.timestamp || Date.now();
         let message = {
             content: String(data.content),
-            timestamp: timestamp,
+            timestamp,
             fromuid: data.uid,
             roomId: data.roomId,
             deleted: 0,
@@ -69,15 +69,15 @@ module.exports = function (Messaging) {
         messages[0].newSet = isNewSet;
         messages[0].mid = mid;
         messages[0].roomId = data.roomId;
-        plugins.hooks.fire('action:messaging.save', { message: messages[0], data: data });
+        plugins.hooks.fire('action:messaging.save', { message: messages[0], data });
         return messages[0];
     };
 
     Messaging.addSystemMessage = async (content, uid, roomId) => {
         const message = await Messaging.addMessage({
-            content: content,
-            uid: uid,
-            roomId: roomId,
+            content,
+            uid,
+            roomId,
             system: 1,
         });
         Messaging.notifyUsersInRoom(uid, roomId, message);

--- a/src/messaging/data.js
+++ b/src/messaging/data.js
@@ -124,11 +124,11 @@ module.exports = function (Messaging) {
         }
 
         const data = await plugins.hooks.fire('filter:messaging.getMessages', {
-            messages: messages,
-            uid: uid,
-            roomId: roomId,
-            isNew: isNew,
-            mids: mids,
+            messages,
+            uid,
+            roomId,
+            isNew,
+            mids,
         });
 
         return data && data.messages;
@@ -147,9 +147,9 @@ async function modifyMessage(message, fields, mid) {
     }
 
     const payload = await plugins.hooks.fire('filter:messaging.getFields', {
-        mid: mid,
-        message: message,
-        fields: fields,
+        mid,
+        message,
+        fields,
     });
 
     return payload.message;

--- a/src/messaging/edit.js
+++ b/src/messaging/edit.js
@@ -7,7 +7,6 @@ const privileges = require('../privileges');
 
 const sockets = require('../socket.io');
 
-
 module.exports = function (Messaging) {
     Messaging.editMessage = async (uid, mid, roomId, content) => {
         await Messaging.checkContent(content);
@@ -17,7 +16,7 @@ module.exports = function (Messaging) {
         }
 
         const payload = await plugins.hooks.fire('filter:messaging.edit', {
-            content: content,
+            content,
             edited: Date.now(),
         });
 
@@ -34,7 +33,7 @@ module.exports = function (Messaging) {
 
         uids.forEach((uid) => {
             sockets.in(`uid_${uid}`).emit('event:chats.edit', {
-                messages: messages,
+                messages,
             });
         });
     };

--- a/src/messaging/index.js
+++ b/src/messaging/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const validator = require('validator');
 
 const db = require('../database');
@@ -57,8 +56,8 @@ Messaging.getMessages = async (params) => {
 
 async function canGet(hook, callerUid, uid) {
     const data = await plugins.hooks.fire(hook, {
-        callerUid: callerUid,
-        uid: uid,
+        callerUid,
+        uid,
         canGet: parseInt(callerUid, 10) === parseInt(uid, 10),
     });
 
@@ -68,12 +67,12 @@ async function canGet(hook, callerUid, uid) {
 Messaging.parse = async (message, fromuid, uid, roomId, isNew) => {
     const parsed = await plugins.hooks.fire('filter:parse.raw', String(message || ''));
     let messageData = {
-        message: message,
-        parsed: parsed,
-        fromuid: fromuid,
-        uid: uid,
-        roomId: roomId,
-        isNew: isNew,
+        message,
+        parsed,
+        fromuid,
+        uid,
+        roomId,
+        isNew,
         parsedMessage: parsed,
     };
 
@@ -132,8 +131,8 @@ Messaging.getRecentChats = async (callerUid, uid, start, stop) => {
     return await plugins.hooks.fire('filter:messaging.getRecentChats', {
         rooms: ref.rooms,
         nextStart: ref.nextStart,
-        uid: uid,
-        callerUid: callerUid,
+        uid,
+        callerUid,
     });
 };
 
@@ -160,7 +159,7 @@ Messaging.getTeaser = async (uid, roomId) => {
         teaser.content = validator.escape(String(teaser.content));
     }
 
-    const payload = await plugins.hooks.fire('filter:messaging.getTeaser', { teaser: teaser });
+    const payload = await plugins.hooks.fire('filter:messaging.getTeaser', { teaser });
     return payload.teaser;
 };
 
@@ -171,7 +170,7 @@ Messaging.getLatestUndeletedMessage = async (uid, roomId) => {
     let mids;
 
     while (!done) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         mids = await db.getSortedSetRevRange(`uid:${uid}:chat:room:${roomId}:mids`, index, index);
         if (mids.length) {
             const states = await Messaging.getMessageFields(mids[0], ['deleted', 'system']);
@@ -223,8 +222,8 @@ Messaging.canMessageUser = async (uid, toUid) => {
     }
 
     await plugins.hooks.fire('static:messaging.canMessageUser', {
-        uid: uid,
-        toUid: toUid,
+        uid,
+        toUid,
     });
 };
 
@@ -248,8 +247,8 @@ Messaging.canMessageRoom = async (uid, roomId) => {
     }
 
     await plugins.hooks.fire('static:messaging.canMessageRoom', {
-        uid: uid,
-        roomId: roomId,
+        uid,
+        roomId,
     });
 };
 
@@ -280,7 +279,7 @@ Messaging.hasPrivateChat = async (uid, withUid) => {
     let index = 0;
     let roomId = 0;
     while (index < roomIds.length && !roomId) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         const count = await Messaging.getUserCountInRoom(roomIds[index]);
         if (count === 2) {
             roomId = roomIds[index];

--- a/src/messaging/notifications.js
+++ b/src/messaging/notifications.js
@@ -16,10 +16,10 @@ module.exports = function (Messaging) {
         uids = await user.blocks.filterUids(fromUid, uids);
 
         let data = {
-            roomId: roomId,
-            fromUid: fromUid,
+            roomId,
+            fromUid,
             message: messageObj,
-            uids: uids,
+            uids,
         };
         data = await plugins.hooks.fire('filter:messaging.notify', data);
         if (!data || !data.uids || !data.uids.length) {

--- a/src/messaging/rooms.js
+++ b/src/messaging/rooms.js
@@ -42,7 +42,7 @@ module.exports = function (Messaging) {
         const roomId = await db.incrObjectField('global', 'nextChatRoomId');
         const room = {
             owner: uid,
-            roomId: roomId,
+            roomId,
         };
 
         await Promise.all([
@@ -61,7 +61,7 @@ module.exports = function (Messaging) {
 
     Messaging.isUserInRoom = async (uid, roomId) => {
         const inRoom = await db.isSortedSetMember(`chat:room:${roomId}:uids`, uid);
-        const data = await plugins.hooks.fire('filter:messaging.isUserInRoom', { uid: uid, roomId: roomId, inRoom: inRoom });
+        const data = await plugins.hooks.fire('filter:messaging.isUserInRoom', { uid, roomId, inRoom });
         return data.inRoom;
     };
 
@@ -196,9 +196,9 @@ module.exports = function (Messaging) {
         }
 
         const payload = await plugins.hooks.fire('filter:chat.renameRoom', {
-            uid: uid,
-            roomId: roomId,
-            newName: newName,
+            uid,
+            roomId,
+            newName,
         });
         const isOwner = await Messaging.isRoomOwner(payload.uid, payload.roomId);
         if (!isOwner) {
@@ -216,7 +216,7 @@ module.exports = function (Messaging) {
 
     Messaging.canReply = async (roomId, uid) => {
         const inRoom = await db.isSortedSetMember(`chat:room:${roomId}:uids`, uid);
-        const data = await plugins.hooks.fire('filter:messaging.canReply', { uid: uid, roomId: roomId, inRoom: inRoom, canReply: inRoom });
+        const data = await plugins.hooks.fire('filter:messaging.canReply', { uid, roomId, inRoom, canReply: inRoom });
         return data.canReply;
     };
 

--- a/src/meta/blacklist.js
+++ b/src/meta/blacklist.js
@@ -33,7 +33,7 @@ Blacklist.load = async function () {
 pubsub.on('blacklist:reload', Blacklist.load);
 
 Blacklist.save = async function (rules) {
-    await db.setObject('ip-blacklist-rules', { rules: rules });
+    await db.setObject('ip-blacklist-rules', { rules });
     await Blacklist.load();
     pubsub.publish('blacklist:reload');
 };
@@ -151,12 +151,12 @@ Blacklist.validate = function (rules) {
 
     return {
         numRules: rules.length + invalid.length,
-        ipv4: ipv4,
-        ipv6: ipv6,
-        cidr: cidr,
+        ipv4,
+        ipv6,
+        cidr,
         valid: rules,
-        invalid: invalid,
-        duplicateCount: duplicateCount,
+        invalid,
+        duplicateCount,
     };
 };
 

--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -85,10 +85,10 @@ async function buildTargets(targets, parallel, options) {
     const otherTargets = targets.filter(target => !targetHandlers.javascript.includes(target));
 
     // Compile TypeScript into JavaScript
-    winston.info(`[build] Building TypeScript files`);
+    winston.info('[build] Building TypeScript files');
     const execAsync = util.promisify(exec);
     await execAsync('npx tsc');
-    winston.info(`[build] TypeScript building complete`);
+    winston.info('[build] TypeScript building complete');
 
     async function buildJSTargets() {
         await Promise.all(
@@ -146,7 +146,7 @@ exports.build = async function (targets, options) {
 
     let series = nconf.get('series') || options.series;
     if (series === undefined) {
-        // Detect # of CPUs and select strategy as appropriate
+    // Detect # of CPUs and select strategy as appropriate
         winston.verbose('[build] Querying CPU core count for build strategy');
         const cpus = os.cpus();
         series = cpus.length < 4;

--- a/src/meta/configs.js
+++ b/src/meta/configs.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const nconf = require('nconf');

--- a/src/meta/css.js
+++ b/src/meta/css.js
@@ -136,7 +136,7 @@ async function getBundleMetadata(target) {
     let imports = `${skinImport}\n${cssImports}\n${lessImports}\n${acpLessImports}`;
     imports = buildImports[target](imports);
 
-    return { paths: paths, imports: imports };
+    return { paths, imports };
 }
 
 CSS.buildBundle = async function (target, fork) {

--- a/src/meta/debugFork.js
+++ b/src/meta/debugFork.js
@@ -28,7 +28,7 @@ function debugFork(modulePath, args, options) {
     }
 
     options = options || {};
-    options = { ...options, execArgv: execArgv };
+    options = { ...options, execArgv };
 
     return fork(modulePath, args, options);
 }

--- a/src/meta/errors.js
+++ b/src/meta/errors.js
@@ -11,9 +11,9 @@ const Errors = module.exports;
 
 let counters = {};
 
-new cronJob('0 * * * * *', (() => {
+new cronJob('0 * * * * *', () => {
     Errors.writeData();
-}), null, true);
+}, null, true);
 
 Errors.writeData = async function () {
     try {

--- a/src/meta/index.js
+++ b/src/meta/index.js
@@ -24,7 +24,6 @@ Meta.templates = require('./templates');
 Meta.blacklist = require('./blacklist');
 Meta.languages = require('./languages');
 
-
 /* Assorted */
 Meta.userOrGroupExists = async function (slug) {
     if (!slug) {

--- a/src/meta/js.js
+++ b/src/meta/js.js
@@ -72,8 +72,8 @@ JS.buildModules = async function () {
 
     const fse = require('fs-extra');
     await fse.copy(
-        path.join(__dirname, `../../public/src`),
-        path.join(__dirname, `../../build/public/src`)
+        path.join(__dirname, '../../public/src'),
+        path.join(__dirname, '../../build/public/src')
     );
 
     await linkModules();
@@ -114,7 +114,7 @@ async function getBundleScriptList(target) {
     pluginScripts = JS.scripts.base.concat(pluginScripts).map((script) => {
         const srcPath = path.resolve(basePath, script).replace(/\\/g, '/');
         return {
-            srcPath: srcPath,
+            srcPath,
             filename: path.relative(basePath, srcPath).replace(/\\/g, '/'),
         };
     });
@@ -129,8 +129,8 @@ JS.buildBundle = async function (target, fork) {
     const filePath = path.join(__dirname, '../../build/public', filename);
 
     await minifier.js.bundle({
-        files: files,
-        filename: filename,
+        files,
+        filename,
         destPath: filePath,
     }, minify, fork);
 };

--- a/src/meta/languages.js
+++ b/src/meta/languages.js
@@ -41,7 +41,6 @@ async function getTranslationMetadata() {
         namespaces.push(namespace);
     });
 
-
     languages = _.union(languages, Plugins.languageData.languages).sort().filter(Boolean);
     namespaces = _.union(namespaces, Plugins.languageData.namespaces).sort().filter(Boolean);
     const configLangs = nconf.get('languages');
@@ -52,8 +51,8 @@ async function getTranslationMetadata() {
     // avoids readdirs later on
     await mkdirp(buildLanguagesPath);
     const result = {
-        languages: languages,
-        namespaces: namespaces,
+        languages,
+        namespaces,
     };
     await fs.promises.writeFile(path.join(buildLanguagesPath, 'metadata.json'), JSON.stringify(result));
     return result;
@@ -120,7 +119,7 @@ async function addPlugin(translations, pluginData, lang, namespace) {
     ]);
 
     for (const language of langs) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         await assignFileToTranslations(translations, path.join(pathToPluginLanguageFolder, language, `${namespace}.json`));
     }
 }

--- a/src/meta/minifier.js
+++ b/src/meta/minifier.js
@@ -95,7 +95,7 @@ function forkAction(action) {
 
         proc.send({
             type: 'action',
-            action: action,
+            action,
         });
     });
 }
@@ -117,7 +117,7 @@ if (process.env.minifier_child) {
                 const result = await actions[action.act](action);
                 process.send({
                     type: 'end',
-                    result: result,
+                    result,
                 });
             } catch (err) {
                 process.send({
@@ -154,7 +154,7 @@ actions.minifyJS_batch = async function minifyJS_batch(data) {
             {
                 srcPath: fileObj.srcPath,
                 filename: fileObj.filename,
-                source: source,
+                source,
             },
         ];
 
@@ -172,7 +172,7 @@ actions.minifyJS = async function minifyJS(data) {
         return {
             srcPath: fileObj.srcPath,
             filename: fileObj.filename,
-            source: source,
+            source,
         };
     });
     await minifyAndSave({
@@ -247,9 +247,9 @@ Minifier.css = {};
 Minifier.css.bundle = async function (source, paths, minify, fork) {
     return await executeAction({
         act: 'buildCSS',
-        source: source,
-        paths: paths,
-        minify: minify,
+        source,
+        paths,
+        minify,
     }, fork);
 };
 

--- a/src/meta/settings.js
+++ b/src/meta/settings.js
@@ -32,7 +32,7 @@ Settings.get = async function (hash) {
         });
     }));
 
-    const result = await plugins.hooks.fire('filter:settings.get', { plugin: hash, values: values });
+    const result = await plugins.hooks.fire('filter:settings.get', { plugin: hash, values });
     cache.set(`settings:${hash}`, result.values);
     return _.cloneDeep(result.values);
 };
@@ -57,7 +57,7 @@ Settings.set = async function (hash, values, quiet) {
     const sortedLists = Object.keys(sortedListData);
 
     if (sortedLists.length) {
-        // Remove provided (but empty) sorted lists from the hash set
+    // Remove provided (but empty) sorted lists from the hash set
         await db.setRemove(`settings:${hash}:sorted-lists`, sortedLists.filter(list => !sortedListData[list].length));
         await db.setAdd(`settings:${hash}:sorted-lists`, sortedLists);
 
@@ -119,7 +119,6 @@ Settings.setOnEmpty = async function (hash, values) {
             empty[key] = values[key];
         }
     });
-
 
     if (Object.keys(empty).length) {
         await Settings.set(hash, empty);

--- a/src/meta/tags.js
+++ b/src/meta/tags.js
@@ -66,7 +66,7 @@ Tags.parse = async (req, data, meta, link) => {
     }, {
         rel: 'manifest',
         href: `${relative_path}/manifest.webmanifest`,
-        crossorigin: `use-credentials`,
+        crossorigin: 'use-credentials',
     }];
 
     if (plugins.hooks.hasListeners('filter:search.query')) {
@@ -144,8 +144,8 @@ Tags.parse = async (req, data, meta, link) => {
     }
 
     const results = await utils.promiseParallel({
-        tags: plugins.hooks.fire('filter:meta.getMetaTags', { req: req, data: data, tags: defaultTags }),
-        links: plugins.hooks.fire('filter:meta.getLinkTags', { req: req, data: data, links: defaultLinks }),
+        tags: plugins.hooks.fire('filter:meta.getMetaTags', { req, data, tags: defaultTags }),
+        links: plugins.hooks.fire('filter:meta.getLinkTags', { req, data, links: defaultLinks }),
     });
 
     meta = results.tags.tags.concat(meta || []).map((tag) => {

--- a/src/middleware/admin.js
+++ b/src/middleware/admin.js
@@ -77,7 +77,7 @@ middleware.renderHeader = async (req, res, data) => {
         env: !!process.env.NODE_ENV,
         title: `${acpPath || 'Dashboard'} | NodeBB Admin Control Panel`,
         bodyClass: data.bodyClass,
-        version: version,
+        version,
         latestVersion: results.latestVersion,
         upgradeAvailable: results.latestVersion && semver.gt(results.latestVersion, version),
         showManageMenu: results.privileges.superadmin || ['categories', 'privileges', 'users', 'admins-mods', 'groups', 'tags', 'settings'].some(priv => results.privileges[`admin:${priv}`]),
@@ -128,7 +128,7 @@ middleware.checkPrivileges = helpers.try(async (req, res, next) => {
             return controllers.helpers.notAllowed(req, res);
         }
     } else {
-        // If accessing /admin, check for any valid admin privs
+    // If accessing /admin, check for any valid admin privs
         const privilegeSet = await privileges.admin.get(req.uid);
         if (!Object.values(privilegeSet).some(Boolean)) {
             return controllers.helpers.notAllowed(req, res);

--- a/src/middleware/expose.js
+++ b/src/middleware/expose.js
@@ -11,7 +11,7 @@ const utils = require('../utils');
 
 module.exports = function (middleware) {
     middleware.exposeAdmin = async (req, res, next) => {
-        // Unlike `requireAdmin`, this middleware just checks the uid, and sets `isAdmin` in `res.locals`
+    // Unlike `requireAdmin`, this middleware just checks the uid, and sets `isAdmin` in `res.locals`
         res.locals.isAdmin = false;
 
         if (!req.user) {
@@ -23,7 +23,7 @@ module.exports = function (middleware) {
     };
 
     middleware.exposePrivileges = async (req, res, next) => {
-        // Exposes a hash of user's ranks (admin, gmod, etc.)
+    // Exposes a hash of user's ranks (admin, gmod, etc.)
         const hash = await utils.promiseParallel({
             isAdmin: user.isAdministrator(req.user.uid),
             isGmod: user.isGlobalModerator(req.user.uid),
@@ -39,7 +39,7 @@ module.exports = function (middleware) {
     };
 
     middleware.exposePrivilegeSet = async (req, res, next) => {
-        // Exposes a user's global/admin privilege set
+    // Exposes a user's global/admin privilege set
         res.locals.privileges = {
             ...await privileges.global.get(req.user.uid),
             ...await privileges.admin.get(req.user.uid),

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -37,7 +37,7 @@ middleware.buildHeader = helpers.try(async (req, res, next) => {
     const [config, canLoginIfBanned] = await Promise.all([
         controllers.api.loadConfig(req),
         user.bans.canLoginIfBanned(req.uid),
-        plugins.hooks.fire('filter:middleware.buildHeader', { req: req, locals: res.locals }),
+        plugins.hooks.fire('filter:middleware.buildHeader', { req, locals: res.locals }),
     ]);
 
     if (!canLoginIfBanned && req.loggedIn) {
@@ -149,10 +149,10 @@ middleware.renderHeader = async function renderHeader(req, res, data) {
     }
 
     const hookReturn = await plugins.hooks.fire('filter:middleware.renderHeader', {
-        req: req,
-        res: res,
-        templateValues: templateValues,
-        data: data,
+        req,
+        res,
+        templateValues,
+        data,
     });
 
     return await req.app.renderAsync('header', hookReturn.templateValues);
@@ -161,7 +161,7 @@ middleware.renderHeader = async function renderHeader(req, res, data) {
 async function appendUnreadCounts({ uid, navigation, unreadData, query }) {
     const originalRoutes = navigation.map(nav => nav.originalRoute);
     const calls = {
-        unreadData: topics.getUnreadData({ uid: uid, query: query }),
+        unreadData: topics.getUnreadData({ uid, query }),
         unreadChatCount: messaging.getUnreadCount(uid),
         unreadNotificationCount: user.notifications.getUnreadCount(uid),
         unreadFlagCount: (async function () {
@@ -232,9 +232,9 @@ async function appendUnreadCounts({ uid, navigation, unreadData, query }) {
 
 middleware.renderFooter = async function renderFooter(req, res, templateValues) {
     const data = await plugins.hooks.fire('filter:middleware.renderFooter', {
-        req: req,
-        res: res,
-        templateValues: templateValues,
+        req,
+        res,
+        templateValues,
     });
 
     const scripts = await plugins.hooks.fire('filter:scripts.get', []);

--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -80,8 +80,8 @@ module.exports = function (middleware) {
 
     middleware.autoLocale = helpers.try(async (req, res, next) => {
         await plugins.hooks.fire('filter:middleware.autoLocale', {
-            req: req,
-            res: res,
+            req,
+            res,
         });
         if (req.query.lang) {
             const langs = await listCodes();

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -82,7 +82,7 @@ middleware.pageView = helpers.try(async (req, res, next) => {
     }
     next();
     await analytics.pageView({ ip: req.ip, uid: req.uid });
-    plugins.hooks.fire('action:middleware.pageView', { req: req });
+    plugins.hooks.fire('action:middleware.pageView', { req });
 });
 
 middleware.pluginHooks = helpers.try(async (req, res, next) => {
@@ -92,8 +92,8 @@ middleware.pluginHooks = helpers.try(async (req, res, next) => {
     });
 
     await plugins.hooks.fire('response:router.page', {
-        req: req,
-        res: res,
+        req,
+        res,
     });
 
     if (!res.headersSent) {

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -14,7 +14,7 @@ const relative_path = nconf.get('relative_path');
 
 module.exports = function (middleware) {
     middleware.processRender = function processRender(req, res, next) {
-        // res.render post-processing, modified from here: https://gist.github.com/mrlannigan/5051687
+    // res.render post-processing, modified from here: https://gist.github.com/mrlannigan/5051687
         const { render } = res;
 
         res.render = async function renderOverride(template, options, fn) {
@@ -37,13 +37,13 @@ module.exports = function (middleware) {
                     res.set('cache-control', 'private');
                 }
 
-                const buildResult = await plugins.hooks.fire(`filter:${template}.build`, { req: req, res: res, templateData: options });
+                const buildResult = await plugins.hooks.fire(`filter:${template}.build`, { req, res, templateData: options });
                 if (res.headersSent) {
                     return;
                 }
                 const templateToRender = buildResult.templateData.templateToRender || template;
 
-                const renderResult = await plugins.hooks.fire('filter:middleware.render', { req: req, res: res, templateData: buildResult.templateData });
+                const renderResult = await plugins.hooks.fire('filter:middleware.render', { req, res, templateData: buildResult.templateData });
                 if (res.headersSent) {
                     return;
                 }
@@ -55,8 +55,8 @@ module.exports = function (middleware) {
                     template: `${template}.tpl`,
                     url: options.url,
                     templateData: options,
-                    req: req,
-                    res: res,
+                    req,
+                    res,
                 });
                 res.locals.template = template;
                 options._locals = undefined;

--- a/src/middleware/uploads.js
+++ b/src/middleware/uploads.js
@@ -26,4 +26,3 @@ exports.ratelimit = helpers.try(async (req, res, next) => {
     cache.set(`${req.ip}:uploaded_file_count`, count);
     next();
 });
-

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -71,8 +71,8 @@ module.exports = function (middleware) {
         }
 
         await plugins.hooks.fire('response:middleware.authenticate', {
-            req: req,
-            res: res,
+            req,
+            res,
             next: function () {}, // no-op for backwards compatibility
         });
 
@@ -112,7 +112,7 @@ module.exports = function (middleware) {
     });
 
     async function ensureSelfOrMethod(method, req, res, next) {
-        /*
+    /*
             The "self" part of this middleware hinges on you having used
             middleware.exposeUid prior to invoking this middleware.
         */
@@ -158,7 +158,7 @@ module.exports = function (middleware) {
     });
 
     middleware.checkAccountPermissions = helpers.try(async (req, res, next) => {
-        // This middleware ensures that only the requested user and admins can pass
+    // This middleware ensures that only the requested user and admins can pass
 
         // This check if left behind for legacy purposes. Older plugins may call this middleware without ensureLoggedIn
         if (!req.loggedIn) {
@@ -224,7 +224,7 @@ module.exports = function (middleware) {
     };
 
     middleware.registrationComplete = async function registrationComplete(req, res, next) {
-        // If the user's session contains registration data, redirect the user to complete registration
+    // If the user's session contains registration data, redirect the user to complete registration
         if (!req.session.hasOwnProperty('registration')) {
             return setImmediate(next);
         }

--- a/src/navigation/admin.js
+++ b/src/navigation/admin.js
@@ -39,7 +39,7 @@ admin.getAdmin = async function () {
         admin.get(),
         getAvailable(),
     ]);
-    return { enabled: enabled, available: available };
+    return { enabled, available };
 };
 
 const fieldsToEscape = ['iconClass', 'class', 'route', 'id', 'text', 'textClass', 'title'];

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -130,7 +130,7 @@ Notifications.create = async function (data) {
     const now = Date.now();
     data.datetime = now;
     const result = await plugins.hooks.fire('filter:notifications.create', {
-        data: data,
+        data,
     });
     if (!result.data) {
         return null;
@@ -184,7 +184,7 @@ async function pushToUids(uids, notification) {
     }
 
     async function sendEmail(uids) {
-        // Update CTA messaging (as not all notification types need custom text)
+    // Update CTA messaging (as not all notification types need custom text)
         if (['new-reply', 'new-chat'].includes(notification.type)) {
             notification['cta-type'] = notification.type;
         }
@@ -201,8 +201,8 @@ async function pushToUids(uids, notification) {
                 notification_url: notification.path.startsWith('http') ? notification.path : nconf.get('url') + notification.path,
                 subject: utils.stripHTMLTags(notification.subject || '[[notifications:new_notification]]'),
                 intro: utils.stripHTMLTags(notification.bodyShort),
-                body: body,
-                notification: notification,
+                body,
+                notification,
                 showUnsubscribe: true,
             }).catch((err) => {
                 if (!errorLogged) {
@@ -228,12 +228,12 @@ async function pushToUids(uids, notification) {
                 uidsToEmail.push(userSettings.uid);
             }
         });
-        return { uidsToNotify: uidsToNotify, uidsToEmail: uidsToEmail };
+        return { uidsToNotify, uidsToEmail };
     }
 
     // Remove uid from recipients list if they have blocked the user triggering the notification
     uids = await User.blocks.filterUids(notification.from, uids);
-    const data = await plugins.hooks.fire('filter:notification.push', { notification: notification, uids: uids });
+    const data = await plugins.hooks.fire('filter:notification.push', { notification, uids });
     if (!data || !data.notification || !data.uids || !data.uids.length) {
         return;
     }
@@ -248,7 +248,7 @@ async function pushToUids(uids, notification) {
         sendEmail(results.uidsToEmail),
     ]);
     plugins.hooks.fire('action:notification.pushed', {
-        notification: notification,
+        notification,
         uids: results.uidsToNotify,
         uidsNotified: results.uidsToNotify,
         uidsEmailed: results.uidsToEmail,
@@ -439,7 +439,7 @@ Notifications.merge = async function (notifications) {
     }, notifications);
 
     const data = await plugins.hooks.fire('filter:notifications.merge', {
-        notifications: notifications,
+        notifications,
     });
     return data && data.notifications;
 };

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -42,7 +42,7 @@ pagination.create = function (currentPage, pageCount, queryObj) {
 
     const pages = pagesToShow.map((page) => {
         queryObj.page = page;
-        return { page: page, active: page === currentPage, qs: qs.stringify(queryObj) };
+        return { page, active: page === currentPage, qs: qs.stringify(queryObj) };
     });
 
     for (i = pages.length - 1; i > 0; i -= 1) {
@@ -53,7 +53,7 @@ pagination.create = function (currentPage, pageCount, queryObj) {
         }
     }
 
-    const data = { rel: [], pages: pages, currentPage: currentPage, pageCount: pageCount };
+    const data = { rel: [], pages, currentPage, pageCount };
     queryObj.page = previous;
     data.prev = { page: previous, active: currentPage > 1, qs: qs.stringify(queryObj) };
     queryObj.page = next;

--- a/src/password.js
+++ b/src/password.js
@@ -26,7 +26,7 @@ const forkChildAsync = util.promisify(forkChild);
 
 exports.hash = async function (rounds, password) {
     password = crypto.createHash('sha512').update(password).digest('hex');
-    return await forkChildAsync({ type: 'hash', rounds: rounds, password: password });
+    return await forkChildAsync({ type: 'hash', rounds, password });
 };
 
 exports.compare = async function (password, hash, shaWrapped) {
@@ -36,7 +36,7 @@ exports.compare = async function (password, hash, shaWrapped) {
         password = crypto.createHash('sha512').update(password).digest('hex');
     }
 
-    return await forkChildAsync({ type: 'compare', password: password, hash: hash || fakeHash });
+    return await forkChildAsync({ type: 'compare', password, hash: hash || fakeHash });
 };
 
 let fakeHashCache;
@@ -60,7 +60,7 @@ process.on('message', (msg) => {
 async function tryMethod(method, msg) {
     try {
         const result = await method(msg);
-        process.send({ result: result });
+        process.send({ result });
     } catch (err) {
         process.send({ err: err.message });
     } finally {

--- a/src/plugins/data.js
+++ b/src/plugins/data.js
@@ -74,7 +74,7 @@ function parseLicense(packageData) {
             text: licenseData.licenseText,
         };
     } catch (e) {
-        // No license matched
+    // No license matched
         return null;
     }
 }
@@ -83,7 +83,6 @@ Data.getActive = async function () {
     const pluginPaths = await Data.getPluginPaths();
     return await Promise.all(pluginPaths.map(p => Data.loadPluginInfo(p)));
 };
-
 
 Data.getStaticDirectories = async function (pluginData) {
     const validMappedPath = /^[\w\-_]+$/;
@@ -135,7 +134,6 @@ Data.getStaticDirectories = async function (pluginData) {
     return staticDirs;
 };
 
-
 Data.getFiles = async function (pluginData, type) {
     if (!Array.isArray(pluginData[type]) || !pluginData[type].length) {
         return;
@@ -172,7 +170,6 @@ async function resolveModulePath(basePath, modulePath) {
     return await resolveModulePath(dirPath, modulePath);
 }
 
-
 Data.getScripts = async function getScripts(pluginData, target) {
     target = (target === 'client') ? 'scripts' : 'acpScripts';
 
@@ -184,7 +181,7 @@ Data.getScripts = async function getScripts(pluginData, target) {
     const scripts = [];
 
     for (const filePath of input) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         const modulePath = await resolveModulePath(pluginData.path, filePath);
         if (modulePath) {
             scripts.push(modulePath);
@@ -195,7 +192,6 @@ Data.getScripts = async function getScripts(pluginData, target) {
     }
     return scripts;
 };
-
 
 Data.getModules = async function getModules(pluginData) {
     if (!pluginData.modules || !pluginData.hasOwnProperty('modules')) {

--- a/src/plugins/hooks.js
+++ b/src/plugins/hooks.js
@@ -82,9 +82,9 @@ Hooks.register = function (id, data) {
     }
 
     if (Array.isArray(data.method) && data.method.every(method => typeof method === 'function' || typeof method === 'string')) {
-        // Go go gadget recursion!
+    // Go go gadget recursion!
         data.method.forEach((method) => {
-            const singularData = { ...data, method: method };
+            const singularData = { ...data, method };
             Hooks.register(id, singularData);
         });
     } else if (typeof data.method === 'string' && data.method.length > 0) {
@@ -132,7 +132,7 @@ Hooks.fire = async function (hook, params) {
     const result = await hookTypeToMethod[hookType](hook, hookList, params);
 
     if (hook !== 'action:plugins.firehook' && hook !== 'filter:plugins.firehook') {
-        const payload = await Hooks.fire('filter:plugins.firehook', { hook: hook, params: result || params });
+        const payload = await Hooks.fire('filter:plugins.firehook', { hook, params: result || params });
         Hooks.fire('action:plugins.firehook', payload);
     }
     if (result !== undefined) {
@@ -191,7 +191,7 @@ async function fireFilterHook(hook, hookList, params) {
     }
 
     for (const hookObj of hookList) {
-        // eslint-disable-next-line
+    // eslint-disable-next-line
         params = await fireMethod(hookObj, params);
     }
     return params;

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -52,9 +52,9 @@ Plugins.requireLibrary = function (pluginData) {
         libraryPath = pluginData.path;
         Plugins.libraries[pluginData.id] = require(libraryPath);
     } catch (e) {
-        // DEPRECATED: @1.15.0, remove in version >=1.17
-        // for backwards compatibility
-        // if that fails, fall back to `pluginData.library`
+    // DEPRECATED: @1.15.0, remove in version >=1.17
+    // for backwards compatibility
+    // if that fails, fall back to `pluginData.library`
         if (pluginData.library) {
             winston.warn(`   [plugins/${pluginData.id}] The plugin.json field "library" is deprecated. Please use the package.json field "main" instead.`);
             winston.verbose(`[plugins/${pluginData.id}] See https://github.com/NodeBB/NodeBB/issues/8686`);
@@ -109,7 +109,7 @@ Plugins.reload = async function () {
 
     const paths = await Plugins.getPluginPaths();
     for (const path of paths) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         await Plugins.loadPlugin(path);
     }
 
@@ -149,7 +149,7 @@ Plugins.reload = async function () {
 
 Plugins.reloadRoutes = async function (params) {
     const controllers = require('../controllers');
-    await Plugins.hooks.fire('static:app.load', { app: app, router: params.router, middleware: middleware, controllers: controllers });
+    await Plugins.hooks.fire('static:app.load', { app, router: params.router, middleware, controllers });
     winston.verbose('[plugins] All plugins reloaded and rerouted');
 };
 
@@ -204,7 +204,7 @@ Plugins.normalise = async function (apiReturn) {
     installedPlugins = installedPlugins.filter(plugin => plugin && !plugin.system);
 
     installedPlugins.forEach((plugin) => {
-        // If it errored out because a package.json or plugin.json couldn't be read, no need to do this stuff
+    // If it errored out because a package.json or plugin.json couldn't be read, no need to do this stuff
         if (plugin.error) {
             pluginMap[plugin.id] = pluginMap[plugin.id] || {};
             pluginMap[plugin.id].installed = true;

--- a/src/plugins/install.js
+++ b/src/plugins/install.js
@@ -69,8 +69,8 @@ module.exports = function (Plugins) {
         }
         meta.reloadRequired = true;
         const hook = isActive ? 'deactivate' : 'activate';
-        Plugins.hooks.fire(`action:plugin.${hook}`, { id: id });
-        return { id: id, active: !isActive };
+        Plugins.hooks.fire(`action:plugin.${hook}`, { id });
+        return { id, active: !isActive };
     };
 
     Plugins.checkWhitelist = async function (id, version) {
@@ -97,7 +97,7 @@ module.exports = function (Plugins) {
     };
 
     Plugins.toggleInstall = async function (id, version) {
-        pubsub.publish('plugins:toggleInstall', { hostname: os.hostname(), id: id, version: version });
+        pubsub.publish('plugins:toggleInstall', { hostname: os.hostname(), id, version });
         return await toggleInstall(id, version);
     };
 
@@ -114,7 +114,7 @@ module.exports = function (Plugins) {
         }
         await runPackageManagerCommandAsync(type, id, version || 'latest');
         const pluginData = await Plugins.get(id);
-        Plugins.hooks.fire(`action:plugin.${type}`, { id: id, version: version });
+        Plugins.hooks.fire(`action:plugin.${type}`, { id, version });
         return pluginData;
     }
 
@@ -133,9 +133,8 @@ module.exports = function (Plugins) {
         });
     }
 
-
     Plugins.upgrade = async function (id, version) {
-        pubsub.publish('plugins:upgrade', { hostname: os.hostname(), id: id, version: version });
+        pubsub.publish('plugins:upgrade', { hostname: os.hostname(), id, version });
         return await upgrade(id, version);
     };
 

--- a/src/plugins/usage.js
+++ b/src/plugins/usage.js
@@ -12,9 +12,9 @@ const meta = require('../meta');
 
 module.exports = function (Plugins) {
     Plugins.startJobs = function () {
-        new cronJob('0 0 0 * * *', (() => {
+        new cronJob('0 0 0 * * *', () => {
             Plugins.submitUsageData();
-        }), null, true);
+        }, null, true);
     };
 
     Plugins.submitUsageData = function (callback) {

--- a/src/posts/bookmarks.js
+++ b/src/posts/bookmarks.js
@@ -42,8 +42,8 @@ module.exports = function (Posts) {
         await Posts.setPostField(pid, 'bookmarks', postData.bookmarks);
 
         plugins.hooks.fire(`action:post.${type}`, {
-            pid: pid,
-            uid: uid,
+            pid,
+            uid,
             owner: postData.uid,
             current: hasBookmarked ? 'bookmarked' : 'unbookmarked',
         });

--- a/src/posts/category.js
+++ b/src/posts/category.js
@@ -1,6 +1,4 @@
-
 'use strict';
-
 
 const _ = require('lodash');
 

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -13,7 +13,7 @@ const utils = require('../utils');
 
 module.exports = function (Posts) {
     Posts.create = async function (data) {
-        // This is an internal method, consider using Topics.reply instead
+    // This is an internal method, consider using Topics.reply instead
         const { uid } = data;
         const { tid } = data;
         //  variable isAnonymous will hold the value of the anonymous property from the data object
@@ -35,16 +35,16 @@ module.exports = function (Posts) {
         // added a new boolean to the data scheme, endorsed_by_Instructor
         const pid = await db.incrObjectField('global', 'nextPid');
         let postData = {
-            pid: pid,
-            uid: uid,
-            tid: tid,
-            isAnonymous: isAnonymous,
+            pid,
+            uid,
+            tid,
+            isAnonymous,
             // assigning the value of the isAnonymous variable to the isAnonymous property of the postData object.
-            content: content,
-            timestamp: timestamp,
+            content,
+            timestamp,
             endorsed_by_Instructor: false,
             // assigned type attribute to be the const type
-            type: type,
+            type,
         };
 
         if (data.toPid) {
@@ -57,7 +57,7 @@ module.exports = function (Posts) {
             postData.handle = data.handle;
         }
 
-        let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });
+        let result = await plugins.hooks.fire('filter:post.create', { post: postData, data });
         postData = result.post;
         await db.setObject(`post:${postData.pid}`, postData);
 

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -18,9 +18,9 @@ module.exports = function (Posts) {
         const keys = pids.map(pid => `post:${pid}`);
         const postData = await db.getObjects(keys, fields);
         const result = await plugins.hooks.fire('filter:post.getFields', {
-            pids: pids,
+            pids,
             posts: postData,
-            fields: fields,
+            fields,
         });
         result.posts.forEach(post => modifyPost(post, fields));
         return result.posts;

--- a/src/posts/delete.js
+++ b/src/posts/delete.js
@@ -21,7 +21,7 @@ module.exports = function (Posts) {
 
     async function deleteOrRestore(type, pid, uid) {
         const isDeleting = type === 'delete';
-        await plugins.hooks.fire(`filter:post.${type}`, { pid: pid, uid: uid });
+        await plugins.hooks.fire(`filter:post.${type}`, { pid, uid });
         await Posts.setPostFields(pid, {
             deleted: isDeleting ? 1 : 0,
             deleterUid: isDeleting ? uid : 0,
@@ -37,7 +37,7 @@ module.exports = function (Posts) {
                 db.sortedSetAdd(`cid:${topicData.cid}:pids`, postData.timestamp, pid),
         ]);
         await categories.updateRecentTidForCid(postData.cid);
-        plugins.hooks.fire(`action:post.${type}`, { post: _.clone(postData), uid: uid });
+        plugins.hooks.fire(`action:post.${type}`, { post: _.clone(postData), uid });
         if (type === 'delete') {
             await flags.resolveFlag('post', pid, uid);
         }
@@ -62,13 +62,13 @@ module.exports = function (Posts) {
         });
 
         // deprecated hook
-        await Promise.all(postData.map(p => plugins.hooks.fire('filter:post.purge', { post: p, pid: p.pid, uid: uid })));
+        await Promise.all(postData.map(p => plugins.hooks.fire('filter:post.purge', { post: p, pid: p.pid, uid })));
 
         // new hook
         await plugins.hooks.fire('filter:posts.purge', {
             posts: postData,
             pids: postData.map(p => p.pid),
-            uid: uid,
+            uid,
         });
 
         await Promise.all([
@@ -86,10 +86,10 @@ module.exports = function (Posts) {
         await resolveFlags(postData, uid);
 
         // deprecated hook
-        Promise.all(postData.map(p => plugins.hooks.fire('action:post.purge', { post: p, uid: uid })));
+        Promise.all(postData.map(p => plugins.hooks.fire('action:post.purge', { post: p, uid })));
 
         // new hook
-        plugins.hooks.fire('action:posts.purge', { posts: postData, uid: uid });
+        plugins.hooks.fire('action:posts.purge', { posts: postData, uid });
 
         await db.deleteAll(postData.map(p => `post:${p.pid}`));
     };

--- a/src/posts/diffs.js
+++ b/src/posts/diffs.js
@@ -41,8 +41,8 @@ module.exports = function (Posts) {
         const { pid, uid, oldContent, newContent, edited, topic } = data;
         const editTimestamp = edited || Date.now();
         const diffData = {
-            uid: uid,
-            pid: pid,
+            uid,
+            pid,
         };
         if (oldContent !== newContent) {
             diffData.patch = diff.createPatch('', newContent, oldContent);
@@ -74,10 +74,10 @@ module.exports = function (Posts) {
         const post = await postDiffLoad(pid, since, uid);
 
         return await Posts.edit({
-            uid: uid,
-            pid: pid,
+            uid,
+            pid,
             content: post.content,
-            req: req,
+            req,
             timestamp: since,
             title: post.topic.title,
             tags: post.topic.tags.map(tag => tag.value),
@@ -131,7 +131,7 @@ module.exports = function (Posts) {
     };
 
     async function postDiffLoad(pid, since, uid) {
-        // Retrieves all diffs made since `since` and replays them to reconstruct what the post looked like at `since`
+    // Retrieves all diffs made since `since` and replays them to reconstruct what the post looked like at `since`
         const [post, diffs] = await Promise.all([
             Posts.getPostSummaryByPids([pid], uid, { parse: false }),
             Posts.diffs.get(pid, since),

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -45,7 +45,7 @@ module.exports = function (Posts) {
         const result = await plugins.hooks.fire('filter:post.edit', {
             req: data.req,
             post: editPostData,
-            data: data,
+            data,
             uid: data.uid,
         });
 
@@ -63,7 +63,7 @@ module.exports = function (Posts) {
             await Posts.diffs.save({
                 pid: data.pid,
                 uid: data.uid,
-                oldContent: oldContent,
+                oldContent,
                 newContent: data.content,
                 edited: editPostData.edited,
                 topic,
@@ -89,7 +89,7 @@ module.exports = function (Posts) {
         });
         await topics.syncBacklinks(returnPostData);
 
-        plugins.hooks.fire('action:post.edit', { post: _.clone(returnPostData), data: data, uid: data.uid });
+        plugins.hooks.fire('action:post.edit', { post: _.clone(returnPostData), data, uid: data.uid });
 
         require('./cache').del(String(postData.pid));
         pubsub.publish('post:edit', String(postData.pid));
@@ -97,8 +97,8 @@ module.exports = function (Posts) {
         await Posts.parsePost(returnPostData);
 
         return {
-            topic: topic,
-            editor: editor,
+            topic,
+            editor,
             post: returnPostData,
         };
     };
@@ -110,7 +110,7 @@ module.exports = function (Posts) {
         const isMain = parseInt(data.pid, 10) === parseInt(topicData.mainPid, 10);
         if (!isMain) {
             return {
-                tid: tid,
+                tid,
                 cid: topicData.cid,
                 title: validator.escape(String(topicData.title)),
                 isMainPost: false,
@@ -120,7 +120,7 @@ module.exports = function (Posts) {
         }
 
         const newTopicData = {
-            tid: tid,
+            tid,
             cid: topicData.cid,
             uid: postData.uid,
             mainPid: data.pid,
@@ -145,7 +145,7 @@ module.exports = function (Posts) {
         const results = await plugins.hooks.fire('filter:topic.edit', {
             req: data.req,
             topic: newTopicData,
-            data: data,
+            data,
         });
         await db.setObject(`topic:${tid}`, results.topic);
         if (tagsupdated) {
@@ -162,16 +162,16 @@ module.exports = function (Posts) {
         const renamed = title && translator.escape(validator.escape(String(title))) !== topicData.title;
         plugins.hooks.fire('action:topic.edit', { topic: newTopicData, uid: data.uid });
         return {
-            tid: tid,
+            tid,
             cid: newTopicData.cid,
             uid: postData.uid,
             title: validator.escape(String(title)),
             oldTitle: topicData.title,
             slug: newTopicData.slug || topicData.slug,
             isMainPost: true,
-            renamed: renamed,
-            tagsupdated: tagsupdated,
-            tags: tags,
+            renamed,
+            tagsupdated,
+            tags,
             oldTags: topicData.tags,
             rescheduled: rescheduling(data, topicData),
         };

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -46,7 +46,7 @@ Posts.getPostsByPids = async function (pids, uid) {
     }
     let posts = await Posts.getPostsData(pids);
     posts = await Promise.all(posts.map(Posts.parsePost));
-    const data = await plugins.hooks.fire('filter:post.getPosts', { posts: posts, uid: uid });
+    const data = await plugins.hooks.fire('filter:post.getPosts', { posts, uid });
     if (!data || !Array.isArray(data.posts)) {
         return [];
     }
@@ -57,7 +57,7 @@ Posts.getPostSummariesFromSet = async function (set, uid, start, stop) {
     let pids = await db.getSortedSetRevRange(set, start, stop);
     pids = await privileges.posts.filter('topics:read', pids, uid);
     const posts = await Posts.getPostSummaryByPids(pids, uid, { stripTags: false });
-    return { posts: posts, nextStart: stop + 1 };
+    return { posts, nextStart: stop + 1 };
 };
 
 Posts.getPidIndex = async function (pid, tid, topicPostSort) {

--- a/src/posts/parse.js
+++ b/src/posts/parse.js
@@ -13,10 +13,10 @@ const utils = require('../utils');
 
 let sanitizeConfig = {
     allowedTags: sanitize.defaults.allowedTags.concat([
-        // Some safe-to-use tags to add
+    // Some safe-to-use tags to add
         'sup', 'ins', 'del', 'img', 'button',
         'video', 'audio', 'iframe', 'embed',
-        // 'sup' still necessary until https://github.com/apostrophecms/sanitize-html/pull/422 merged
+    // 'sup' still necessary until https://github.com/apostrophecms/sanitize-html/pull/422 merged
     ]),
     allowedAttributes: {
         ...sanitize.defaults.allowedAttributes,
@@ -60,7 +60,7 @@ module.exports = function (Posts) {
             return postData;
         }
 
-        const data = await plugins.hooks.fire('filter:parse.post', { postData: postData });
+        const data = await plugins.hooks.fire('filter:parse.post', { postData });
         data.postData.content = translator.escape(data.postData.content);
         if (data.postData.pid) {
             cache.set(pid, data.postData.content);
@@ -70,11 +70,11 @@ module.exports = function (Posts) {
 
     Posts.parseSignature = async function (userData, uid) {
         userData.signature = sanitizeSignature(userData.signature || '');
-        return await plugins.hooks.fire('filter:parse.signature', { userData: userData, uid: uid });
+        return await plugins.hooks.fire('filter:parse.signature', { userData, uid });
     };
 
     Posts.relativeToAbsolute = function (content, regex) {
-        // Turns relative links in content to absolute urls
+    // Turns relative links in content to absolute urls
         if (!content) {
             return content;
         }
@@ -117,7 +117,7 @@ module.exports = function (Posts) {
     };
 
     Posts.configureSanitize = async () => {
-        // Each allowed tags should have some common global attributes...
+    // Each allowed tags should have some common global attributes...
         sanitizeConfig.allowedTags.forEach((tag) => {
             sanitizeConfig.allowedAttributes[tag] = _.union(
                 sanitizeConfig.allowedAttributes[tag],

--- a/src/posts/queue.js
+++ b/src/posts/queue.js
@@ -91,8 +91,8 @@ module.exports = function (Posts) {
                 userData.postcount <= 0);
         const result = await plugins.hooks.fire('filter:post.shouldQueue', {
             shouldQueue: !!shouldQueue,
-            uid: uid,
-            data: data,
+            uid,
+            data,
         });
         return result.shouldQueue;
     };
@@ -141,10 +141,10 @@ module.exports = function (Posts) {
         await canPost(type, data);
 
         let payload = {
-            id: id,
+            id,
             uid: data.uid,
-            type: type,
-            data: data,
+            type,
+            data,
         };
         payload = await plugins.hooks.fire('filter:post-queue.save', payload);
         payload.data = JSON.stringify(data);
@@ -163,13 +163,13 @@ module.exports = function (Posts) {
             nid: `post-queue-${id}`,
             mergeId: 'post-queue',
             bodyShort: '[[notifications:post_awaiting_review]]',
-            bodyLong: bodyLong,
+            bodyLong,
             path: `/post-queue/${id}`,
         });
         await notifications.push(notifObj, uids);
         return {
-            id: id,
-            type: type,
+            id,
+            type,
             queued: true,
             message: '[[success:post-queued]]',
         };
@@ -188,17 +188,17 @@ module.exports = function (Posts) {
             userData.url = `${url}/uid/${userData.uid}`;
         }
 
-        const topic = { cid: cid, title: data.title, tid: data.tid };
+        const topic = { cid, title: data.title, tid: data.tid };
         if (type === 'reply') {
             topic.title = await topics.getTopicField(data.tid, 'title');
             topic.url = `${url}/topic/${data.tid}`;
         }
         const { app } = require('../webserver');
         return await app.renderAsync('emails/partials/post-queue-body', {
-            content: content,
-            category: category,
+            content,
+            category,
             user: userData,
-            topic: topic,
+            topic,
         });
     }
 
@@ -240,7 +240,7 @@ module.exports = function (Posts) {
         if (!data) {
             return null;
         }
-        const result = await plugins.hooks.fire('filter:post-queue:removeFromQueue', { data: data });
+        const result = await plugins.hooks.fire('filter:post-queue:removeFromQueue', { data });
         await removeFromQueue(id);
         plugins.hooks.fire('action:post-queue:removeFromQueue', { data: result.data });
         return result.data;
@@ -258,7 +258,7 @@ module.exports = function (Posts) {
         if (!data) {
             return null;
         }
-        const result = await plugins.hooks.fire('filter:post-queue:submitFromQueue', { data: data });
+        const result = await plugins.hooks.fire('filter:post-queue:submitFromQueue', { data });
         data = result.data;
         if (data.type === 'topic') {
             const result = await createTopic(data.data);
@@ -268,7 +268,7 @@ module.exports = function (Posts) {
             data.pid = result.pid;
         }
         await removeFromQueue(id);
-        plugins.hooks.fire('action:post-queue:submitFromQueue', { data: data });
+        plugins.hooks.fire('action:post-queue:submitFromQueue', { data });
         return data;
     };
 
@@ -359,7 +359,7 @@ module.exports = function (Posts) {
                 post.data.tid = newTid;
             });
             await db.setObjectBulk(
-                postData.map(p => [`post:queue:${p.id}`, { data: JSON.stringify(p.data) }]),
+                postData.map(p => [`post:queue:${p.id}`, { data: JSON.stringify(p.data) }])
             );
             cache.del('post-queue');
         }

--- a/src/posts/recent.js
+++ b/src/posts/recent.js
@@ -5,7 +5,6 @@ const _ = require('lodash');
 const db = require('../database');
 const privileges = require('../privileges');
 
-
 module.exports = function (Posts) {
     const terms = {
         day: 86400000,

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const validator = require('validator');
@@ -61,7 +60,7 @@ module.exports = function (Posts) {
         posts = posts.filter(post => tidToTopic[post.tid]);
 
         posts = await parsePosts(posts, options);
-        const result = await plugins.hooks.fire('filter:post.getPostSummaryByPids', { posts: posts, uid: uid });
+        const result = await plugins.hooks.fire('filter:post.getPostSummaryByPids', { posts, uid });
         return result.posts;
     };
 

--- a/src/posts/topics.js
+++ b/src/posts/topics.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const topics = require('../topics');

--- a/src/posts/uploads.js
+++ b/src/posts/uploads.js
@@ -44,7 +44,7 @@ module.exports = function (Posts) {
     }
 
     Posts.uploads.sync = async function (pid) {
-        // Scans a post's content and updates sorted set of uploads
+    // Scans a post's content and updates sorted set of uploads
 
         const [content, currentUploads, isMainPost] = await Promise.all([
             Posts.getPostField(pid, 'content'),
@@ -138,7 +138,7 @@ module.exports = function (Posts) {
     };
 
     Posts.uploads.getUsage = async function (filePaths) {
-        // Given an array of file names, determines which pids they are used in
+    // Given an array of file names, determines which pids they are used in
         if (!Array.isArray(filePaths)) {
             filePaths = [filePaths];
         }
@@ -148,7 +148,7 @@ module.exports = function (Posts) {
     };
 
     Posts.uploads.associate = async function (pid, filePaths) {
-        // Adds an upload to a post's sorted set of uploads
+    // Adds an upload to a post's sorted set of uploads
         filePaths = !Array.isArray(filePaths) ? [filePaths] : filePaths;
         if (!filePaths.length) {
             return;
@@ -168,7 +168,7 @@ module.exports = function (Posts) {
     };
 
     Posts.uploads.dissociate = async function (pid, filePaths) {
-        // Removes an upload from a post's sorted set of uploads
+    // Removes an upload from a post's sorted set of uploads
         filePaths = !Array.isArray(filePaths) ? [filePaths] : filePaths;
         if (!filePaths.length) {
             return;

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -107,9 +107,9 @@ module.exports = function (Posts) {
             'lastonline', 'groupTitle', 'mutedUntil',
         ];
         const result = await plugins.hooks.fire('filter:posts.addUserFields', {
-            fields: fields,
-            uid: uid,
-            uids: uids,
+            fields,
+            uid,
+            uids,
         });
         return await user.getUsersFields(result.uids, _.uniq(result.fields));
     }
@@ -183,7 +183,7 @@ module.exports = function (Posts) {
 
         plugins.hooks.fire('action:post.changeOwner', {
             posts: _.cloneDeep(postData),
-            toUid: toUid,
+            toUid,
         });
         return postData;
     };
@@ -245,7 +245,7 @@ module.exports = function (Posts) {
         const changedTopics = mainPosts.map(p => tidToTopic[p.tid]);
         plugins.hooks.fire('action:topic.changeOwner', {
             topics: _.cloneDeep(changedTopics),
-            toUid: toUid,
+            toUid,
         });
     }
 

--- a/src/posts/votes.js
+++ b/src/posts/votes.js
@@ -140,7 +140,7 @@ module.exports = function (Posts) {
     }
 
     async function checkVoteLimitation(pid, uid, type) {
-        // type = 'upvote' or 'downvote'
+    // type = 'upvote' or 'downvote'
         const oneDay = 86400000;
         const [reputation, targetUid, votedPidsToday] = await Promise.all([
             user.getUserField(uid, 'reputation'),
@@ -217,9 +217,9 @@ module.exports = function (Posts) {
         // action:post.unvote
         plugins.hooks.fire(`action:post.${hook}`, {
             pid: postData.pid,
-            uid: uid,
+            uid,
             owner: postData.uid,
-            current: current,
+            current,
         });
     }
 

--- a/src/prestart.js
+++ b/src/prestart.js
@@ -80,7 +80,6 @@ function loadConfig(configFile) {
     nconf.set('upload_path', path.resolve(nconf.get('base_dir'), nconf.get('upload_path')));
     nconf.set('upload_url', '/assets/uploads');
 
-
     // nconf defaults, if not set in config
     if (!nconf.get('sessionKey')) {
         nconf.set('sessionKey', 'express.sid');

--- a/src/privileges/admin.js
+++ b/src/privileges/admin.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -188,7 +187,7 @@ privsAdmin.canGroup = async function (privilege, groupName) {
 privsAdmin.give = async function (privileges, groupName) {
     await helpers.giveOrRescind(groups.join, privileges, 0, groupName);
     plugins.hooks.fire('action:privileges.admin.give', {
-        privileges: privileges,
+        privileges,
         groupNames: Array.isArray(groupName) ? groupName : [groupName],
     });
 };
@@ -196,7 +195,7 @@ privsAdmin.give = async function (privileges, groupName) {
 privsAdmin.rescind = async function (privileges, groupName) {
     await helpers.giveOrRescind(groups.leave, privileges, 0, groupName);
     plugins.hooks.fire('action:privileges.admin.rescind', {
-        privileges: privileges,
+        privileges,
         groupNames: Array.isArray(groupName) ? groupName : [groupName],
     });
 };

--- a/src/privileges/categories.js
+++ b/src/privileges/categories.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -97,11 +96,11 @@ privsCategories.get = async function (cid, uid) {
 
     return await plugins.hooks.fire('filter:privileges.categories.get', {
         ...privData,
-        cid: cid,
-        uid: uid,
+        cid,
+        uid,
         editable: isAdminOrMod,
         view_deleted: isAdminOrMod || privData['posts:view_deleted'],
-        isAdminOrMod: isAdminOrMod,
+        isAdminOrMod,
     });
 };
 
@@ -186,7 +185,7 @@ privsCategories.filterUids = async function (privilege, cid, uids) {
 privsCategories.give = async function (privileges, cid, members) {
     await helpers.giveOrRescind(groups.join, privileges, cid, members);
     plugins.hooks.fire('action:privileges.categories.give', {
-        privileges: privileges,
+        privileges,
         cids: Array.isArray(cid) ? cid : [cid],
         members: Array.isArray(members) ? members : [members],
     });
@@ -195,7 +194,7 @@ privsCategories.give = async function (privileges, cid, members) {
 privsCategories.rescind = async function (privileges, cid, members) {
     await helpers.giveOrRescind(groups.leave, privileges, cid, members);
     plugins.hooks.fire('action:privileges.categories.rescind', {
-        privileges: privileges,
+        privileges,
         cids: Array.isArray(cid) ? cid : [cid],
         members: Array.isArray(members) ? members : [members],
     });

--- a/src/privileges/global.js
+++ b/src/privileges/global.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -112,7 +111,7 @@ privsGlobal.filterUids = async function (privilege, uids) {
 privsGlobal.give = async function (privileges, groupName) {
     await helpers.giveOrRescind(groups.join, privileges, 0, groupName);
     plugins.hooks.fire('action:privileges.global.give', {
-        privileges: privileges,
+        privileges,
         groupNames: Array.isArray(groupName) ? groupName : [groupName],
     });
 };
@@ -120,7 +119,7 @@ privsGlobal.give = async function (privileges, groupName) {
 privsGlobal.rescind = async function (privileges, groupName) {
     await helpers.giveOrRescind(groups.leave, privileges, 0, groupName);
     plugins.hooks.fire('action:privileges.global.rescind', {
-        privileges: privileges,
+        privileges,
         groupNames: Array.isArray(groupName) ? groupName : [groupName],
     });
 };

--- a/src/privileges/helpers.js
+++ b/src/privileges/helpers.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -22,7 +21,7 @@ helpers.isUsersAllowedTo = async function (privilege, uids, cid) {
         groups.isMembersOfGroupList(uids, `cid:${cid}:privileges:groups:${privilege}`),
     ]);
     const allowed = uids.map((uid, index) => hasUserPrivilege[index] || hasGroupPrivilege[index]);
-    const result = await plugins.hooks.fire('filter:privileges:isUsersAllowedTo', { allowed: allowed, privilege: privilege, uids: uids, cid: cid });
+    const result = await plugins.hooks.fire('filter:privileges:isUsersAllowedTo', { allowed, privilege, uids, cid });
     return result.allowed;
 };
 
@@ -34,7 +33,7 @@ helpers.isAllowedTo = async function (privilege, uidOrGroupName, cid) {
         allowed = await isAllowedToCids(privilege, uidOrGroupName, cid);
     }
     if (allowed) {
-        ({ allowed } = await plugins.hooks.fire('filter:privileges:isAllowedTo', { allowed: allowed, privilege: privilege, uid: uidOrGroupName, cid: cid }));
+        ({ allowed } = await plugins.hooks.fire('filter:privileges:isAllowedTo', { allowed, privilege, uid: uidOrGroupName, cid }));
         return allowed;
     }
     throw new Error('[[error:invalid-data]]');

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -48,9 +47,9 @@ privsPosts.get = async function (pids, uid) {
         const viewHistory = results.isOwner[i] || privData['posts:history'][cid] || results.isAdmin;
 
         return {
-            editable: editable,
+            editable,
             move: isAdminOrMod,
-            isAdminOrMod: isAdminOrMod,
+            isAdminOrMod,
             'topics:read': privData['topics:read'][cid] || results.isAdmin,
             read: privData.read[cid] || results.isAdmin,
             'posts:history': viewHistory,
@@ -106,9 +105,9 @@ privsPosts.filter = async function (privilege, pids, uid) {
     )).map(post => post.pid);
 
     const data = await plugins.hooks.fire('filter:privileges.posts.filter', {
-        privilege: privilege,
-        uid: uid,
-        pids: pids,
+        privilege,
+        uid,
+        pids,
     });
 
     return data ? data.pids : null;
@@ -185,7 +184,7 @@ privsPosts.canDelete = async function (pid, uid) {
     }
     const { deleterUid } = postData;
     const flag = results['posts:delete'] && ((results.isOwner && (deleterUid === 0 || deleterUid === postData.uid)) || results.isMod);
-    return { flag: flag, message: '[[error:no-privileges]]' };
+    return { flag, message: '[[error:no-privileges]]' };
 };
 
 privsPosts.canFlag = async function (pid, uid) {

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -49,14 +48,14 @@ privsTopics.get = async function (tid, uid) {
         purge: (privData.purge && (isOwner || isModerator)) || isAdministrator,
 
         view_thread_tools: editable || deletable,
-        editable: editable,
-        deletable: deletable,
+        editable,
+        deletable,
         view_deleted: isAdminOrMod || isOwner || privData['posts:view_deleted'],
         view_scheduled: privData['topics:schedule'] || isAdministrator,
-        isAdminOrMod: isAdminOrMod,
-        disabled: disabled,
-        tid: tid,
-        uid: uid,
+        isAdminOrMod,
+        disabled,
+        tid,
+        uid,
     });
 };
 
@@ -89,9 +88,9 @@ privsTopics.filterTids = async function (privilege, tids, uid) {
     )).map(t => t.tid);
 
     const data = await plugins.hooks.fire('filter:privileges.topics.filter', {
-        privilege: privilege,
-        uid: uid,
-        tids: tids,
+        privilege,
+        uid,
+        tids,
     });
     return data ? data.tids : [];
 };

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -65,7 +64,7 @@ async function isModeratorOfCategory(cid, uid) {
 }
 
 async function filterIsModerator(cid, uid, isModerator) {
-    const data = await plugins.hooks.fire('filter:user.isModerator', { uid: uid, cid: cid, isModerator: isModerator });
+    const data = await plugins.hooks.fire('filter:user.isModerator', { uid, cid, isModerator });
     if ((Array.isArray(uid) || Array.isArray(cid)) && !Array.isArray(data.isModerator)) {
         throw new Error('filter:user.isModerator - i/o mismatch');
     }
@@ -84,12 +83,12 @@ privsUsers.canEdit = async function (callerUid, uid) {
     ]);
 
     const data = await plugins.hooks.fire('filter:user.canEdit', {
-        isAdmin: isAdmin,
-        isGlobalMod: isGlobalMod,
-        isTargetAdmin: isTargetAdmin,
+        isAdmin,
+        isGlobalMod,
+        isTargetAdmin,
         canEdit: isAdmin || (isGlobalMod && !isTargetAdmin),
-        callerUid: callerUid,
-        uid: uid,
+        callerUid,
+        uid,
     });
     return data.canEdit;
 };
@@ -103,8 +102,8 @@ privsUsers.canBanUser = async function (callerUid, uid) {
 
     const data = await plugins.hooks.fire('filter:user.canBanUser', {
         canBan: canBan && !isTargetAdmin,
-        callerUid: callerUid,
-        uid: uid,
+        callerUid,
+        uid,
     });
     return data.canBan;
 };
@@ -118,8 +117,8 @@ privsUsers.canMuteUser = async function (callerUid, uid) {
 
     const data = await plugins.hooks.fire('filter:user.canMuteUser', {
         canMute: canMute && !isTargetAdmin,
-        callerUid: callerUid,
-        uid: uid,
+        callerUid,
+        uid,
     });
     return data.canMute;
 };

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -34,8 +34,8 @@ function get() {
             singleHost.publish = function (event, data) {
                 process.send({
                     action: 'pubsub',
-                    event: event,
-                    data: data,
+                    event,
+                    data,
                 });
             };
             process.on('message', (message) => {

--- a/src/rewards/index.js
+++ b/src/rewards/index.js
@@ -71,8 +71,8 @@ async function checkCondition(reward, method) {
 async function giveRewards(uid, rewards) {
     const rewardData = await getRewardsByRewardData(rewards);
     for (let i = 0; i < rewards.length; i++) {
-        /* eslint-disable no-await-in-loop */
-        await plugins.hooks.fire(`action:rewards.award:${rewards[i].rid}`, { uid: uid, reward: rewardData[i] });
+    /* eslint-disable no-await-in-loop */
+        await plugins.hooks.fire(`action:rewards.award:${rewards[i].rid}`, { uid, reward: rewardData[i] });
         await db.sortedSetIncrBy(`uid:${uid}:rewards`, 1, rewards[i].id);
     }
 }

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -61,7 +61,6 @@ module.exports = function (app, name, middleware, controllers) {
     apiRoutes(app, name, middleware, controllers);
 };
 
-
 function apiRoutes(router, name, middleware, controllers) {
     router.get(`/api/${name}/users/csv`, middleware.ensureLoggedIn, helpers.tryRoute(controllers.admin.users.getCSV));
     router.get(`/api/${name}/groups/:groupname/csv`, middleware.ensureLoggedIn, helpers.tryRoute(controllers.admin.groups.getCSV));

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -65,7 +65,7 @@ Auth.verifyToken = async function (token, done) {
     if (uid !== undefined) {
         if (parseInt(uid, 10) > 0) {
             done(null, {
-                uid: uid,
+                uid,
             });
         } else {
             done(null, {
@@ -182,6 +182,6 @@ passport.serializeUser((user, done) => {
 
 passport.deserializeUser((uid, done) => {
     done(null, {
-        uid: uid,
+        uid,
     });
 });

--- a/src/routes/feeds.js
+++ b/src/routes/feeds.js
@@ -140,7 +140,7 @@ async function generateForCategory(req, res, next) {
         let topicsData = await topics.getTopicsByTids(tids, uid);
         topicsData = await user.blocks.filter(uid, topicsData);
         const feed = await generateTopicsFeed({
-            uid: uid,
+            uid,
             title: category.name,
             description: category.description,
             feed_url: `/category/${cid}.rss`,
@@ -220,10 +220,10 @@ async function generateSorted(options, req, res, next) {
     const uid = token && token === req.query.token ? req.query.uid : req.uid;
 
     const params = {
-        uid: uid,
+        uid,
         start: 0,
         stop: 19,
-        term: term,
+        term,
         sort: options.sort,
     };
 
@@ -237,7 +237,7 @@ async function generateSorted(options, req, res, next) {
 
     const result = await topics.getSortedTopics(params);
     const feed = await generateTopicsFeed({
-        uid: uid,
+        uid,
         title: options.title,
         description: options.description,
         feed_url: options.feed_url,
@@ -297,7 +297,7 @@ async function generateTopicsFeed(feedOptions, feedTopics, timestampField) {
     }
 
     for (const topicData of feedTopics) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         await addFeedItem(topicData);
     }
     return feed;
@@ -412,8 +412,8 @@ async function generateForTag(req, res) {
         description: `A list of topics that have been tagged with ${tag}`,
         feed_url: `/tags/${tag}.rss`,
         site_url: `/tags/${tag}`,
-        start: start,
-        stop: stop,
+        start,
+        stop,
     }, `tag:${tag}:topics`, res);
 }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -147,9 +147,9 @@ module.exports = async function (app, middleware) {
     // homepage handled by `action:homepage.get:[route]`
     setupPageRoute(router, '/', [], controllers.home.pluginHook);
 
-    await plugins.reloadRoutes({ router: router });
-    await authRoutes.reloadRoutes({ router: router });
-    await writeRoutes.reload({ router: router });
+    await plugins.reloadRoutes({ router });
+    await authRoutes.reloadRoutes({ router });
+    await writeRoutes.reload({ router });
     addCoreRoutes(app, router, middleware, mounts);
 
     winston.info('[router] Routes added');

--- a/src/routes/write/index.js
+++ b/src/routes/write/index.js
@@ -22,7 +22,7 @@ Write.reload = async (params) => {
     });
 
     router.use('/api/v3', (req, res, next) => {
-        // Require https if configured so
+    // Require https if configured so
         if (apiSettings.requireHttps === 'on' && req.protocol !== 'https') {
             res.set('Upgrade', 'TLS/1.0, HTTP/1.1');
             return helpers.formatApiResponse(426, res);

--- a/src/search.js
+++ b/src/search.js
@@ -84,7 +84,7 @@ async function searchInContent(data) {
 
     const metadata = await plugins.hooks.fire('filter:search.inContent', {
         pids: allPids,
-        data: data,
+        data,
     });
 
     if (data.returnIds) {
@@ -109,7 +109,7 @@ async function searchInContent(data) {
     }
 
     returnData.posts = await posts.getPostSummaryByPids(metadata.pids, data.uid, {});
-    await plugins.hooks.fire('filter:search.contentGetResult', { result: returnData, data: data });
+    await plugins.hooks.fire('filter:search.contentGetResult', { result: returnData, data });
     delete metadata.pids;
     delete metadata.data;
     return Object.assign(returnData, metadata);
@@ -131,7 +131,7 @@ async function filterAndSort(pids, data) {
 
     sortPosts(postsData, data);
 
-    const result = await plugins.hooks.fire('filter:search.filterAndSort', { pids: pids, posts: postsData, data: data });
+    const result = await plugins.hooks.fire('filter:search.filterAndSort', { pids, posts: postsData, data });
     return result.posts.map(post => post && post.pid);
 }
 

--- a/src/sitemap.js
+++ b/src/sitemap.js
@@ -56,7 +56,7 @@ async function getSitemapPages() {
         priority: 0.4,
     }];
 
-    const data = await plugins.hooks.fire('filter:sitemap.getPages', { urls: urls });
+    const data = await plugins.hooks.fire('filter:sitemap.getPages', { urls });
     return data.urls;
 }
 

--- a/src/socket.io/admin/categories.js
+++ b/src/socket.io/admin/categories.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const categories = require('../../categories');
 
 const Categories = module.exports;
@@ -13,7 +12,7 @@ Categories.copyPrivilegesToChildren = async function (socket, data) {
     const result = await categories.getChildren([data.cid], socket.uid);
     const children = result[0];
     for (const child of children) {
-        // eslint-disable-next-line no-await-in-loop
+    // eslint-disable-next-line no-await-in-loop
         await copyPrivilegesToChildrenRecursive(data.cid, child, data.group, data.filter);
     }
 };
@@ -21,7 +20,7 @@ Categories.copyPrivilegesToChildren = async function (socket, data) {
 async function copyPrivilegesToChildrenRecursive(parentCid, category, group, filter) {
     await categories.copyPrivilegesFrom(parentCid, category.cid, group, filter);
     for (const child of category.children) {
-        // eslint-disable-next-line no-await-in-loop
+    // eslint-disable-next-line no-await-in-loop
         await copyPrivilegesToChildrenRecursive(parentCid, child, group, filter);
     }
 }
@@ -38,7 +37,7 @@ Categories.copyPrivilegesToAllCategories = async function (socket, data) {
     let cids = await categories.getAllCidsFromSet('categories:cid');
     cids = cids.filter(cid => parseInt(cid, 10) !== parseInt(data.cid, 10));
     for (const toCid of cids) {
-        // eslint-disable-next-line no-await-in-loop
+    // eslint-disable-next-line no-await-in-loop
         await categories.copyPrivilegesFrom(data.cid, toCid, data.group, data.filter);
     }
 };

--- a/src/socket.io/admin/digest.js
+++ b/src/socket.io/admin/digest.js
@@ -19,6 +19,6 @@ Digest.resend = async (socket, data) => {
             subscribers: [uid],
         });
     } else {
-        await userDigest.execute({ interval: interval });
+        await userDigest.execute({ interval });
     }
 };

--- a/src/socket.io/admin/rooms.js
+++ b/src/socket.io/admin/rooms.js
@@ -18,7 +18,7 @@ SocketRooms.totals = totals;
 pubsub.on('sync:stats:start', () => {
     const stats = SocketRooms.getLocalStats();
     pubsub.publish('sync:stats:end', {
-        stats: stats,
+        stats,
         id: `${os.hostname()}:${nconf.get('port')}`,
     });
 });
@@ -47,7 +47,6 @@ SocketRooms.getTotalGuestCount = function (callback) {
         callback(null, count);
     }, 100);
 };
-
 
 SocketRooms.getAll = async function () {
     pubsub.publish('sync:stats:start');
@@ -82,7 +81,7 @@ SocketRooms.getAll = async function () {
 
     let topTenTopics = [];
     Object.keys(totals.topics).forEach((tid) => {
-        topTenTopics.push({ tid: tid, count: totals.topics[tid].count || 0 });
+        topTenTopics.push({ tid, count: totals.topics[tid].count || 0 });
     });
 
     topTenTopics = topTenTopics.sort((a, b) => b.count - a.count).slice(0, 10);

--- a/src/socket.io/admin/user.js
+++ b/src/socket.io/admin/user.js
@@ -21,7 +21,7 @@ User.makeAdmins = async function (socket, uids) {
         throw new Error('[[error:cant-make-banned-users-admin]]');
     }
     for (const uid of uids) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         await groups.join('administrators', uid);
         await events.log({
             type: 'user-makeAdmin',
@@ -37,7 +37,7 @@ User.removeAdmins = async function (socket, uids) {
         throw new Error('[[error:invalid-data]]');
     }
     for (const uid of uids) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         const count = await groups.getMemberCount('administrators');
         if (count === 1) {
             throw new Error('[[error:cant-remove-last-admin]]');

--- a/src/socket.io/blacklist.js
+++ b/src/socket.io/blacklist.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const user = require('../user');
@@ -29,7 +28,7 @@ async function blacklist(socket, method, rule) {
         type: `ip-blacklist-${method}`,
         uid: socket.uid,
         ip: socket.ip,
-        rule: rule,
+        rule,
     });
 }
 

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -64,13 +64,13 @@ SocketCategories.loadMore = async function (socket, data) {
     const result = await categories.getCategoryTopics({
         uid: socket.uid,
         cid: data.cid,
-        start: start,
-        stop: stop,
-        sort: sort,
-        settings: settings,
+        start,
+        stop,
+        sort,
+        settings,
         query: data.query,
         tag: data.query.tag,
-        targetUid: targetUid,
+        targetUid,
     });
     categories.modifyTopicsByPrivilege(result.topics, userPrivileges);
 

--- a/src/socket.io/categories/search.js
+++ b/src/socket.io/categories/search.js
@@ -51,7 +51,7 @@ module.exports = function (SocketCategories) {
 
     async function findMatchedCids(uid, data) {
         const result = await categories.search({
-            uid: uid,
+            uid,
             query: data.search,
             qs: data.query,
             paginate: false,
@@ -72,7 +72,7 @@ module.exports = function (SocketCategories) {
 
         return {
             cids: _.uniq(rootCids.concat(allChildCids).concat(matchedCids)),
-            matchedCids: matchedCids,
+            matchedCids,
         };
     }
 

--- a/src/socket.io/groups.js
+++ b/src/socket.io/groups.js
@@ -27,7 +27,7 @@ SocketGroups.addMember = async (socket, data) => {
         throw new Error('[[error:invalid-uid]]');
     }
     for (const uid of data.uid) {
-        // eslint-disable-next-line no-await-in-loop
+    // eslint-disable-next-line no-await-in-loop
         await groups.join(data.groupName, uid);
     }
 
@@ -216,7 +216,7 @@ SocketGroups.loadMoreMembers = async (socket, data) => {
     data.after = parseInt(data.after, 10);
     const users = await groups.getOwnersAndMembers(data.groupName, socket.uid, data.after, data.after + 9);
     return {
-        users: users,
+        users,
         nextStart: data.after + 10,
     };
 };

--- a/src/socket.io/helpers.js
+++ b/src/socket.io/helpers.js
@@ -43,8 +43,8 @@ async function notifyUids(uid, uids, type, result) {
     const data = await plugins.hooks.fire('filter:sockets.sendNewPostToUids', {
         uidsTo: uids,
         uidFrom: uid,
-        type: type,
-        post: post,
+        type,
+        post,
     });
 
     post.ip = undefined;
@@ -101,18 +101,17 @@ SocketHelpers.sendNotificationToPostOwner = async function (pid, fromuid, comman
         type: command,
         bodyShort: `[[${notification}, ${displayname}, ${titleEscaped}]]`,
         bodyLong: postObj.content,
-        pid: pid,
+        pid,
         tid: postData.tid,
         path: `/post/${pid}`,
         nid: `${command}:post:${pid}:uid:${fromuid}`,
         from: fromuid,
         mergeId: `${notification}|${pid}`,
-        topicTitle: topicTitle,
+        topicTitle,
     });
 
     notifications.push(notifObj, [postData.uid]);
 };
-
 
 SocketHelpers.sendNotificationToTopicOwner = async function (tid, fromuid, command, notification) {
     if (!tid || !fromuid || !notification) {

--- a/src/socket.io/index.js
+++ b/src/socket.io/index.js
@@ -80,7 +80,7 @@ function onConnection(socket) {
 
 function onDisconnect(socket) {
     require('./uploads').clear(socket.id);
-    plugins.hooks.fire('action:sockets.disconnect', { socket: socket });
+    plugins.hooks.fire('action:sockets.disconnect', { socket });
 }
 
 async function onConnect(socket) {
@@ -104,7 +104,7 @@ async function onConnect(socket) {
     socket.join(`sess_${socket.request.signedCookies[nconf.get('sessionKey')]}`);
     socket.emit('checkSession', socket.uid);
     socket.emit('setHostname', os.hostname());
-    plugins.hooks.fire('action:sockets.connect', { socket: socket });
+    plugins.hooks.fire('action:sockets.connect', { socket });
 }
 
 async function onMessage(socket, payload) {
@@ -217,8 +217,8 @@ async function validateSession(socket, errorMsg) {
     }
 
     await plugins.hooks.fire('static:sockets.validateSession', {
-        req: req,
-        socket: socket,
+        req,
+        socket,
         session: sessionData,
     });
 }
@@ -236,7 +236,7 @@ async function authorize(socket, callback) {
 
     const { sessionId } = await plugins.hooks.fire('filter:sockets.sessionId', {
         sessionId: request.signedCookies ? request.signedCookies[nconf.get('sessionKey')] : null,
-        request: request,
+        request,
     });
 
     const sessionData = await getSessionAsync(sessionId);
@@ -271,7 +271,7 @@ Sockets.warnDeprecated = (socket, replacement) => {
     if (socket.previousEvents && socket.emit) {
         socket.emit('event:deprecated_call', {
             eventName: socket.previousEvents[socket.previousEvents.length - 1],
-            replacement: replacement,
+            replacement,
         });
     }
     winston.warn(`[deprecated]\n ${new Error('-').stack.split('\n').slice(2, 5).join('\n')}\n     use ${replacement}`);

--- a/src/socket.io/meta.js
+++ b/src/socket.io/meta.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const user = require('../user');
 const topics = require('../topics');
 

--- a/src/socket.io/modules.js
+++ b/src/socket.io/modules.js
@@ -180,7 +180,7 @@ SocketModules.chats.markRead = async function (socket, roomId) {
     ]);
 
     Messaging.pushUnreadCount(socket.uid);
-    server.in(`uid_${socket.uid}`).emit('event:chats.markedAsRead', { roomId: roomId });
+    server.in(`uid_${socket.uid}`).emit('event:chats.markedAsRead', { roomId });
 
     if (!uidsInRoom.includes(String(socket.uid))) {
         return;

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -29,7 +29,7 @@ SocketPosts.getRawPost = async function (socket, pid) {
         throw new Error('[[error:no-post]]');
     }
     postData.pid = pid;
-    const result = await plugins.hooks.fire('filter:post.getRawPost', { uid: socket.uid, postData: postData });
+    const result = await plugins.hooks.fire('filter:post.getRawPost', { uid: socket.uid, postData });
     return result.postData.content;
 };
 
@@ -158,10 +158,10 @@ async function canEditQueue(socket, data, action) {
 
 async function sendQueueNotification(type, targetUid, path, notificationText) {
     const notifData = {
-        type: type,
+        type,
         nid: `${type}-${targetUid}-${path}`,
         bodyShort: notificationText ? `[[notifications:${type}, ${notificationText}]]` : `[[notifications:${type}]]`,
-        path: path,
+        path,
     };
     if (parseInt(meta.config.postQueueNotificationUid, 10) > 0) {
         notifData.from = meta.config.postQueueNotificationUid;

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -84,9 +84,9 @@ module.exports = function (SocketPosts) {
             uid: socket.uid,
             ip: socket.ip,
             targetUid: data.toUid,
-            pid: pid,
+            pid,
             originalUid: uid,
-            cid: cid,
+            cid,
         })));
 
         await Promise.all(logs);

--- a/src/socket.io/posts/votes.js
+++ b/src/socket.io/posts/votes.js
@@ -30,9 +30,9 @@ module.exports = function (SocketPosts) {
         return {
             upvoteCount: upvoters.length,
             downvoteCount: downvoters.length,
-            showDownvotes: showDownvotes,
-            upvoters: upvoters,
-            downvoters: downvoters,
+            showDownvotes,
+            upvoters,
+            downvoters,
         };
     };
 
@@ -53,8 +53,8 @@ module.exports = function (SocketPosts) {
             }
             const usernames = await user.getUsernamesByUids(uids);
             return {
-                otherCount: otherCount,
-                usernames: usernames,
+                otherCount,
+                usernames,
             };
         }));
         return result;

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -49,7 +49,7 @@ SocketTopics.createTopicFromPosts = async function (socket, data) {
 
     const result = await topics.createTopicFromPosts(socket.uid, data.title, data.pids, data.fromTid);
     await events.log({
-        type: `topic-fork`,
+        type: 'topic-fork',
         uid: socket.uid,
         ip: socket.ip,
         pids: String(data.pids),

--- a/src/socket.io/topics/merge.js
+++ b/src/socket.io/topics/merge.js
@@ -18,10 +18,10 @@ module.exports = function (SocketTopics) {
         }
         const mergeIntoTid = await topics.merge(data.tids, socket.uid, data.options);
         await events.log({
-            type: `topic-merge`,
+            type: 'topic-merge',
             uid: socket.uid,
             ip: socket.ip,
-            mergeIntoTid: mergeIntoTid,
+            mergeIntoTid,
             tids: String(data.tids),
         });
         return mergeIntoTid;

--- a/src/socket.io/topics/move.js
+++ b/src/socket.io/topics/move.js
@@ -37,16 +37,15 @@ module.exports = function (SocketTopics) {
             }
 
             await events.log({
-                type: `topic-move`,
+                type: 'topic-move',
                 uid: socket.uid,
                 ip: socket.ip,
-                tid: tid,
+                tid,
                 fromCid: topicData.cid,
                 toCid: data.cid,
             });
         });
     };
-
 
     SocketTopics.moveAll = async function (socket, data) {
         if (!data || !data.cid || !data.currentCid) {
@@ -63,7 +62,7 @@ module.exports = function (SocketTopics) {
             await topics.tools.move(tid, data);
         });
         await events.log({
-            type: `topic-move-all`,
+            type: 'topic-move-all',
             uid: socket.uid,
             ip: socket.ip,
             fromCid: data.currentCid,

--- a/src/socket.io/topics/unread.js
+++ b/src/socket.io/topics/unread.js
@@ -33,7 +33,7 @@ module.exports = function (SocketTopics) {
     };
 
     SocketTopics.markCategoryTopicsRead = async function (socket, cid) {
-        const tids = await topics.getUnreadTids({ cid: cid, uid: socket.uid, filter: '' });
+        const tids = await topics.getUnreadTids({ cid, uid: socket.uid, filter: '' });
         await SocketTopics.markAsRead(socket, tids);
     };
 

--- a/src/socket.io/uploads.js
+++ b/src/socket.io/uploads.js
@@ -29,7 +29,8 @@ uploads.upload = async function (socket, data) {
 
     try {
         const maxSize = data.params.method === 'user.uploadCroppedPicture' ?
-            meta.config.maximumProfileImageSize : meta.config.maximumCoverImageSize;
+            meta.config.maximumProfileImageSize :
+            meta.config.maximumCoverImageSize;
         const size = image.sizeFromBase64(socketUploads[method].imageData);
 
         if (size > maxSize * 1024) {

--- a/src/socket.io/user.js
+++ b/src/socket.io/user.js
@@ -49,10 +49,10 @@ SocketUser.reset.send = async function (socket, email) {
     async function logEvent(text) {
         await events.log({
             type: 'password-reset',
-            text: text,
+            text,
             ip: socket.ip,
             uid: socket.uid,
-            email: email,
+            email,
         });
     }
     try {
@@ -81,7 +81,7 @@ SocketUser.reset.commit = async function (socket, data) {
 
     await events.log({
         type: 'password-reset',
-        uid: uid,
+        uid,
         ip: socket.ip,
     });
 
@@ -89,7 +89,7 @@ SocketUser.reset.commit = async function (socket, data) {
     const now = new Date();
     const parsedDate = `${now.getFullYear()}/${now.getMonth() + 1}/${now.getDate()}`;
     emailer.send('reset_notify', uid, {
-        username: username,
+        username,
         date: parsedDate,
         subject: '[[email:reset.notify.subject]]',
     }).catch(err => winston.error(`[emailer.send] ${err.stack}`));

--- a/src/socket.io/user/status.js
+++ b/src/socket.io/user/status.js
@@ -22,7 +22,7 @@ module.exports = function (SocketUser) {
             throw new Error('[[error:invalid-user-status]]');
         }
 
-        const userData = { status: status };
+        const userData = { status };
         if (status !== 'offline') {
             userData.lastonline = Date.now();
         }
@@ -32,7 +32,7 @@ module.exports = function (SocketUser) {
         }
         const eventData = {
             uid: socket.uid,
-            status: status,
+            status,
         };
         websockets.server.emit('event:user_status_change', eventData);
         return eventData;

--- a/src/topics/bookmarks.js
+++ b/src/topics/bookmarks.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const async = require('async');

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -17,18 +16,18 @@ const translator = require('../translator');
 
 module.exports = function (Topics) {
     Topics.create = async function (data) {
-        // This is an internal method, consider using Topics.post instead
+    // This is an internal method, consider using Topics.post instead
         const timestamp = data.timestamp || Date.now();
         const tid = await db.incrObjectField('global', 'nextTid');
         // added the endorsed attribute to the front end
         let topicData = {
-            tid: tid,
+            tid,
             uid: data.uid,
             cid: data.cid,
             mainPid: 0,
             title: data.title,
             slug: `${tid}/${slugify(data.title) || 'topic'}`,
-            timestamp: timestamp,
+            timestamp,
             lastposttime: 0,
             postcount: 0,
             viewcount: 0,
@@ -40,7 +39,7 @@ module.exports = function (Topics) {
             topicData.tags = data.tags.join(',');
         }
 
-        const result = await plugins.hooks.fire('filter:topic.create', { topic: topicData, data: data });
+        const result = await plugins.hooks.fire('filter:topic.create', { topic: topicData, data });
         topicData = result.topic;
         await db.setObject(`topic:${topicData.tid}`, topicData);
 
@@ -73,7 +72,7 @@ module.exports = function (Topics) {
             await Topics.scheduled.pin(tid, topicData);
         }
 
-        plugins.hooks.fire('action:topic.save', { topic: _.clone(topicData), data: data });
+        plugins.hooks.fire('action:topic.save', { topic: _.clone(topicData), data });
         return topicData.tid;
     };
 
@@ -144,15 +143,15 @@ module.exports = function (Topics) {
         }
 
         analytics.increment(['topics', `topics:byCid:${topicData.cid}`]);
-        plugins.hooks.fire('action:topic.post', { topic: topicData, post: postData, data: data });
+        plugins.hooks.fire('action:topic.post', { topic: topicData, post: postData, data });
 
         if (parseInt(uid, 10) && !topicData.scheduled) {
             user.notifications.sendTopicNotificationToFollowers(uid, topicData, postData);
         }
 
         return {
-            topicData: topicData,
-            postData: postData,
+            topicData,
+            postData,
         };
     };
 
@@ -206,7 +205,7 @@ module.exports = function (Topics) {
         }
 
         analytics.increment(['posts', `posts:byCid:${data.cid}`]);
-        plugins.hooks.fire('action:topic.reply', { post: _.clone(postData), data: data });
+        plugins.hooks.fire('action:topic.reply', { post: _.clone(postData), data });
 
         return postData;
     };
@@ -255,7 +254,7 @@ module.exports = function (Topics) {
     };
 
     function check(item, min, max, minError, maxError) {
-        // Trim and remove HTML (latter for composers that send in HTML, like redactor)
+    // Trim and remove HTML (latter for composers that send in HTML, like redactor)
         if (typeof item === 'string') {
             item = utils.stripHTMLTags(item).trim();
         }

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -29,10 +29,10 @@ module.exports = function (Topics) {
         const keys = tids.map(tid => `topic:${tid}`);
         const topics = await db.getObjects(keys, fields);
         const result = await plugins.hooks.fire('filter:topic.getFields', {
-            tids: tids,
-            topics: topics,
-            fields: fields,
-            keys: keys,
+            tids,
+            topics,
+            fields,
+            keys,
         });
         result.topics.forEach(topic => modifyTopic(topic, fields));
         return result.topics;

--- a/src/topics/delete.js
+++ b/src/topics/delete.js
@@ -8,7 +8,6 @@ const categories = require('../categories');
 const plugins = require('../plugins');
 const batch = require('../batch');
 
-
 module.exports = function (Topics) {
     Topics.delete = async function (tid, uid) {
         await removeTopicPidsFromCid(tid);
@@ -94,7 +93,7 @@ module.exports = function (Topics) {
             Topics.thumbs.deleteAll(tid),
             reduceCounters(tid),
         ]);
-        plugins.hooks.fire('action:topic.purge', { topic: deletedTopic, uid: uid });
+        plugins.hooks.fire('action:topic.purge', { topic: deletedTopic, uid });
         await db.delete(`topic:${tid}`);
     };
 

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -49,7 +49,7 @@ Events._types = {
     },
     move: {
         icon: 'fa-arrow-circle-right',
-        // text: '[[topic:moved-from-by]]',
+    // text: '[[topic:moved-from-by]]',
     },
     'post-queue': {
         icon: 'fa-history',
@@ -132,7 +132,7 @@ async function modifyEvent({ tid, uid, eventIds, timestamps, events }) {
     if (meta.config.topicBacklinks !== 1) {
         events = events.filter(event => event.type !== 'backlink');
     } else {
-        // remove backlinks that we dont have read permission
+    // remove backlinks that we dont have read permission
         const backlinkPids = events.filter(e => e.type === 'backlink')
             .map(e => e.href.split('/').pop());
         const pids = await privileges.posts.filter('topics:read', backlinkPids, uid);

--- a/src/topics/follow.js
+++ b/src/topics/follow.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const db = require('../database');
@@ -44,7 +43,7 @@ module.exports = function (Topics) {
         }
         await method1(tid, uid);
         await method2(tid, uid);
-        plugins.hooks.fire(hook, { uid: uid, tid: tid });
+        plugins.hooks.fire(hook, { uid, tid });
     }
 
     async function follow(tid, uid) {

--- a/src/topics/fork.js
+++ b/src/topics/fork.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const db = require('../database');
@@ -41,12 +40,12 @@ module.exports = function (Topics) {
         const scheduled = postData.timestamp > Date.now();
         const params = {
             uid: postData.uid,
-            title: title,
-            cid: cid,
+            title,
+            cid,
             timestamp: scheduled && postData.timestamp,
         };
         const result = await plugins.hooks.fire('filter:topic.fork', {
-            params: params,
+            params,
             tid: postData.tid,
         });
 
@@ -73,7 +72,7 @@ module.exports = function (Topics) {
             Topics.events.log(fromTid, { type: 'fork', uid, href: `/topic/${tid}`, timestamp: postData.timestamp }),
         ]);
 
-        plugins.hooks.fire('action:topic.fork', { tid: tid, fromTid: fromTid, uid: uid });
+        plugins.hooks.fire('action:topic.fork', { tid, fromTid, uid });
 
         return await Topics.getTopicData(tid);
     };
@@ -114,7 +113,7 @@ module.exports = function (Topics) {
             Topics.updateLastPostTimeFromLastPid(tid),
             Topics.updateLastPostTimeFromLastPid(postData.tid),
         ]);
-        plugins.hooks.fire('action:post.move', { uid: callerUid, post: postData, tid: tid });
+        plugins.hooks.fire('action:post.move', { uid: callerUid, post: postData, tid });
     };
 
     async function updateCategory(postData, toTid) {

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -45,7 +45,7 @@ Topics.getTopicsFromSet = async function (set, uid, start, stop) {
     const tids = await db.getSortedSetRevRange(set, start, stop);
     const topics = await Topics.getTopics(tids, uid);
     Topics.calculateTopicIndices(topics, start);
-    return { topics: topics, nextStart: stop + 1 };
+    return { topics, nextStart: stop + 1 };
 };
 
 Topics.getTopics = async function (tids, options) {
@@ -154,7 +154,7 @@ Topics.getTopicsByTids = async function (tids, options) {
         }
     });
     const filteredTopics = result.topics.filter(topic => topic && topic.category && !topic.category.disabled);
-    const hookResult = await plugins.hooks.fire('filter:topics.get', { topics: filteredTopics, uid: uid });
+    const hookResult = await plugins.hooks.fire('filter:topics.get', { topics: filteredTopics, uid });
     return hookResult.topics;
 };
 
@@ -176,7 +176,7 @@ Topics.getTopicWithPosts = async function (topicData, set, uid, start, stop, rev
         Topics.getTopicPosts(topicData, set, start, stop, uid, reverse),
         categories.getCategoryData(topicData.cid),
         categories.getTagWhitelist([topicData.cid]),
-        plugins.hooks.fire('filter:topic.thread_tools', { topic: topicData, uid: uid, tools: [] }),
+        plugins.hooks.fire('filter:topic.thread_tools', { topic: topicData, uid, tools: [] }),
         Topics.getFollowData([topicData.tid], uid),
         Topics.getUserBookmark(topicData.tid, uid),
         social.getActivePostSharing(),
@@ -230,7 +230,7 @@ Topics.getTopicWithPosts = async function (topicData, set, uid, start, stop, rev
     topicData.unreplied = topicData.postcount === 1;
     topicData.icons = [];
 
-    const result = await plugins.hooks.fire('filter:topic.get', { topic: topicData, uid: uid });
+    const result = await plugins.hooks.fire('filter:topic.get', { topic: topicData, uid });
     return result.topic;
 };
 
@@ -295,8 +295,8 @@ Topics.search = async function (tid, term) {
         throw new Error('[[error:invalid-data]]');
     }
     const result = await plugins.hooks.fire('filter:topic.search', {
-        tid: tid,
-        term: term,
+        tid,
+        term,
         ids: [],
     });
     return Array.isArray(result) ? result : result.ids;

--- a/src/topics/merge.js
+++ b/src/topics/merge.js
@@ -33,7 +33,7 @@ module.exports = function (Topics) {
             await Topics.setTopicField(tid, 'mainPid', 0);
             await Topics.delete(tid, uid);
             await Topics.setTopicFields(tid, {
-                mergeIntoTid: mergeIntoTid,
+                mergeIntoTid,
                 mergerUid: uid,
                 mergedTimestamp: Date.now(),
             });
@@ -45,10 +45,10 @@ module.exports = function (Topics) {
         ]);
 
         plugins.hooks.fire('action:topic.merge', {
-            uid: uid,
-            tids: tids,
-            mergeIntoTid: mergeIntoTid,
-            otherTids: otherTids,
+            uid,
+            tids,
+            mergeIntoTid,
+            otherTids,
         });
         return mergeIntoTid;
     };
@@ -58,11 +58,11 @@ module.exports = function (Topics) {
         const params = {
             uid: topicData.uid,
             cid: topicData.cid,
-            title: title,
+            title,
         };
         const result = await plugins.hooks.fire('filter:topic.mergeCreateNewTopic', {
-            oldestTid: oldestTid,
-            params: params,
+            oldestTid,
+            params,
         });
         const tid = await Topics.create(result.params);
         return tid;

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -69,7 +68,7 @@ module.exports = function (Topics) {
 
         const result = await plugins.hooks.fire('filter:topic.getPosts', {
             topic: topicData,
-            uid: uid,
+            uid,
             posts: await Topics.addPostData(postData, uid),
         });
         return result.posts;
@@ -159,7 +158,7 @@ module.exports = function (Topics) {
 
         const result = await plugins.hooks.fire('filter:topics.addPostData', {
             posts: postData,
-            uid: uid,
+            uid,
         });
         return result.posts;
     };

--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const db = require('../database');
@@ -16,20 +15,20 @@ module.exports = function (Topics) {
     Topics.getRecentTopics = async function (cid, uid, start, stop, filter) {
         return await Topics.getSortedTopics({
             cids: cid,
-            uid: uid,
-            start: start,
-            stop: stop,
-            filter: filter,
+            uid,
+            start,
+            stop,
+            filter,
             sort: 'recent',
         });
     };
 
     /* not an orphan method, used in widget-essentials */
     Topics.getLatestTopics = async function (options) {
-        // uid, start, stop, term
+    // uid, start, stop, term
         const tids = await Topics.getLatestTidsFromSet('topics:recent', options.start, options.stop, options.term);
         const topics = await Topics.getTopics(tids, options);
-        return { topics: topics, nextStart: options.stop + 1 };
+        return { topics, nextStart: options.stop + 1 };
     };
 
     Topics.getLatestTidsFromSet = async function (set, start, stop, term) {
@@ -68,9 +67,9 @@ module.exports = function (Topics) {
     };
 
     Topics.updateRecent = async function (tid, timestamp) {
-        let data = { tid: tid, timestamp: timestamp };
+        let data = { tid, timestamp };
         if (plugins.hooks.hasListeners('filter:topics.updateRecent')) {
-            data = await plugins.hooks.fire('filter:topics.updateRecent', { tid: tid, timestamp: timestamp });
+            data = await plugins.hooks.fire('filter:topics.updateRecent', { tid, timestamp });
         }
         if (data && data.tid && data.timestamp) {
             await db.sortedSetAdd('topics:recent', data.timestamp, data.tid);

--- a/src/topics/scheduled.js
+++ b/src/topics/scheduled.js
@@ -41,7 +41,7 @@ Scheduled.handleExpired = async function () {
         sendNotifications(uids, topicsData),
         updateUserLastposttimes(uids, topicsData),
         ...topicsData.map(topicData => unpin(topicData.tid, topicData)),
-        db.sortedSetsRemoveRangeByScore([`topics:scheduled`], '-inf', now)
+        db.sortedSetsRemoveRangeByScore(['topics:scheduled'], '-inf', now)
     ));
 };
 

--- a/src/topics/sorted.js
+++ b/src/topics/sorted.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -39,7 +38,7 @@ module.exports = function (Topics) {
 
     async function getTids(params) {
         if (plugins.hooks.hasListeners('filter:topics.getSortedTids')) {
-            const result = await plugins.hooks.fire('filter:topics.getSortedTids', { params: params, tids: [] });
+            const result = await plugins.hooks.fire('filter:topics.getSortedTids', { params, tids: [] });
             return result.tids;
         }
         let tids = [];
@@ -55,7 +54,7 @@ module.exports = function (Topics) {
         } else if (params.tags.length) {
             tids = await getTagTids(params);
         } else if (params.sort === 'old') {
-            tids = await db.getSortedSetRange(`topics:recent`, 0, meta.config.recentMaxTopics - 1);
+            tids = await db.getSortedSetRange('topics:recent', 0, meta.config.recentMaxTopics - 1);
         } else {
             tids = await db.getSortedSetRevRange(`topics:${params.sort}`, 0, meta.config.recentMaxTopics - 1);
         }
@@ -74,7 +73,7 @@ module.exports = function (Topics) {
             'getSortedSetIntersect' :
             'getSortedSetRevIntersect';
         return await db[method]({
-            sets: sets,
+            sets,
             start: 0,
             stop: meta.config.recentMaxTopics - 1,
             weights: sets.map((s, index) => (index ? 0 : 1)),
@@ -199,7 +198,7 @@ module.exports = function (Topics) {
             (!cids || cids.includes(String(t.cid)))
         )).map(t => t.tid);
 
-        const result = await plugins.hooks.fire('filter:topics.filterSortedTids', { tids: tids, params: params });
+        const result = await plugins.hooks.fire('filter:topics.filterSortedTids', { tids, params });
         return result.tids;
     }
 

--- a/src/topics/suggested.js
+++ b/src/topics/suggested.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -51,7 +50,7 @@ module.exports = function (Topics) {
             searchIn: 'titles',
             matchWords: 'any',
             categories: [topicData.cid],
-            uid: uid,
+            uid,
             returnIds: true,
             timeRange: cutoff !== 0 ? cutoff / 1000 : 0,
             timeFilter: 'newer',

--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const async = require('async');
@@ -30,7 +29,7 @@ module.exports = function (Topics) {
     };
 
     Topics.filterTags = async function (tags, cid) {
-        const result = await plugins.hooks.fire('filter:tags.filter', { tags: tags, cid: cid });
+        const result = await plugins.hooks.fire('filter:tags.filter', { tags, cid });
         tags = _.uniq(result.tags)
             .map(tag => utils.cleanUpTag(tag, meta.config.maximumTagLength))
             .filter(tag => tag && tag.length >= (meta.config.minimumTagLength || 3));
@@ -164,7 +163,7 @@ module.exports = function (Topics) {
                 }
             });
             await db.setObjectBulk(
-                topicData.map(t => [`topic:${t.tid}`, { tags: t.tags.join(',') }]),
+                topicData.map(t => [`topic:${t.tid}`, { tags: t.tags.join(',') }])
             );
         }, {});
         await Topics.deleteTag(tag);
@@ -237,7 +236,7 @@ module.exports = function (Topics) {
 
             await db.deleteObjectFields(
                 tids.map(tid => `topic:${tid}`),
-                ['tags'],
+                ['tags']
             );
         });
     }
@@ -283,7 +282,7 @@ module.exports = function (Topics) {
         }
 
         const payload = await plugins.hooks.fire('filter:tags.getAll', {
-            tags: tags,
+            tags,
         });
         return await Topics.getTagData(payload.tags);
     }
@@ -409,11 +408,11 @@ module.exports = function (Topics) {
         }
         let result;
         if (plugins.hooks.hasListeners('filter:topics.searchTags')) {
-            result = await plugins.hooks.fire('filter:topics.searchTags', { data: data });
+            result = await plugins.hooks.fire('filter:topics.searchTags', { data });
         } else {
             result = await findMatches(data);
         }
-        result = await plugins.hooks.fire('filter:tags.search', { data: data, matches: result.matches });
+        result = await plugins.hooks.fire('filter:tags.search', { data, matches: result.matches });
         return result.matches;
     };
 
@@ -423,7 +422,7 @@ module.exports = function (Topics) {
         }
         let result;
         if (plugins.hooks.hasListeners('filter:topics.autocompleteTags')) {
-            result = await plugins.hooks.fire('filter:topics.autocompleteTags', { data: data });
+            result = await plugins.hooks.fire('filter:topics.autocompleteTags', { data });
         } else {
             result = await findMatches(data);
         }
@@ -481,7 +480,7 @@ module.exports = function (Topics) {
             }
             return 0;
         });
-        return { matches: matches };
+        return { matches };
     }
 
     Topics.searchAndLoadTags = async function (data) {
@@ -510,7 +509,7 @@ module.exports = function (Topics) {
 
     Topics.getRelatedTopics = async function (topicData, uid) {
         if (plugins.hooks.hasListeners('filter:topic.getRelatedTopics')) {
-            const result = await plugins.hooks.fire('filter:topic.getRelatedTopics', { topic: topicData, uid: uid, topics: [] });
+            const result = await plugins.hooks.fire('filter:topic.getRelatedTopics', { topic: topicData, uid, topics: [] });
             return result.topics;
         }
 

--- a/src/topics/teaser.js
+++ b/src/topics/teaser.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -87,7 +86,7 @@ module.exports = function (Topics) {
             return topicPost;
         });
 
-        const result = await plugins.hooks.fire('filter:teasers.get', { teasers: teasers, uid: uid });
+        const result = await plugins.hooks.fire('filter:teasers.get', { teasers, uid });
         return result.teasers;
     };
 

--- a/src/topics/thumbs.js
+++ b/src/topics/thumbs.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -10,7 +10,6 @@ const plugins = require('../plugins');
 const privileges = require('../privileges');
 const utils = require('../utils');
 
-
 module.exports = function (Topics) {
     const topicTools = {};
     Topics.tools = topicTools;
@@ -35,7 +34,7 @@ module.exports = function (Topics) {
         const canDelete = await privileges.topics.canDelete(tid, uid);
 
         const hook = isDelete ? 'delete' : 'restore';
-        const data = await plugins.hooks.fire(`filter:topic.${hook}`, { topicData: topicData, uid: uid, isDelete: isDelete, canDelete: canDelete, canRestore: canDelete });
+        const data = await plugins.hooks.fire(`filter:topic.${hook}`, { topicData, uid, isDelete, canDelete, canRestore: canDelete });
 
         if ((!data.canDelete && data.isDelete) || (!data.canRestore && !data.isDelete)) {
             throw new Error('[[error:no-privileges]]');
@@ -81,7 +80,7 @@ module.exports = function (Topics) {
         }
 
         await Topics.purgePostsAndTopic(tid, uid);
-        return { tid: tid, cid: topicData.cid, uid: uid };
+        return { tid, cid: topicData.cid, uid };
     };
 
     topicTools.lock = async function (tid, uid) {
@@ -106,7 +105,7 @@ module.exports = function (Topics) {
         topicData.isLocked = lock; // deprecate in v2.0
         topicData.locked = lock;
 
-        plugins.hooks.fire('action:topic.lock', { topic: _.clone(topicData), uid: uid });
+        plugins.hooks.fire('action:topic.lock', { topic: _.clone(topicData), uid });
         return topicData;
     }
 
@@ -130,7 +129,7 @@ module.exports = function (Topics) {
         }
 
         await Topics.setTopicField(tid, 'pinExpiry', expiry);
-        plugins.hooks.fire('action:topic.setPinExpiry', { topic: _.clone(topicData), uid: uid });
+        plugins.hooks.fire('action:topic.setPinExpiry', { topic: _.clone(topicData), uid });
     };
 
     topicTools.checkPinExpiry = async (tids) => {
@@ -279,8 +278,8 @@ module.exports = function (Topics) {
             categories.updateRecentTidForCid(cid),
             categories.updateRecentTidForCid(oldCid),
             Topics.setTopicFields(tid, {
-                cid: cid,
-                oldCid: oldCid,
+                cid,
+                oldCid,
             }),
             Topics.updateCategoryTagsCount([oldCid, cid], tags),
             Topics.events.log(tid, { type: 'move', uid: data.uid, fromCid: oldCid }),

--- a/src/topics/unread.js
+++ b/src/topics/unread.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const async = require('async');
@@ -17,7 +16,7 @@ const plugins = require('../plugins');
 module.exports = function (Topics) {
     Topics.getTotalUnread = async function (uid, filter) {
         filter = filter || '';
-        const counts = await Topics.getUnreadTids({ cid: 0, uid: uid, count: true });
+        const counts = await Topics.getUnreadTids({ cid: 0, uid, count: true });
         return counts && counts[filter];
     };
 
@@ -48,7 +47,7 @@ module.exports = function (Topics) {
 
     Topics.unreadCutoff = async function (uid) {
         const cutoff = Date.now() - (meta.config.unreadCutoff * 86400000);
-        const data = await plugins.hooks.fire('filter:topics.unreadCutoff', { uid: uid, cutoff: cutoff });
+        const data = await plugins.hooks.fire('filter:topics.unreadCutoff', { uid, cutoff });
         return parseInt(data.cutoff, 10);
     };
 
@@ -72,7 +71,7 @@ module.exports = function (Topics) {
         }
 
         const result = await plugins.hooks.fire('filter:topics.getUnreadTids', {
-            uid: uid,
+            uid,
             tids: data.tids,
             counts: data.counts,
             tidsByFilter: data.tidsByFilter,
@@ -88,7 +87,7 @@ module.exports = function (Topics) {
         const tidsByFilter = { '': [], new: [], watched: [], unreplied: [] };
 
         if (params.uid <= 0) {
-            return { counts: counts, tids: [], tidsByFilter: tidsByFilter };
+            return { counts, tids: [], tidsByFilter };
         }
 
         params.cutoff = await Topics.unreadCutoff(params.uid);
@@ -123,15 +122,15 @@ module.exports = function (Topics) {
         let tids = _.uniq(unreadTopics.map(topic => topic.value)).slice(0, 200);
 
         if (!tids.length) {
-            return { counts: counts, tids: tids, tidsByFilter: tidsByFilter };
+            return { counts, tids, tidsByFilter };
         }
 
         const blockedUids = await user.blocks.list(params.uid);
 
         tids = await filterTidsThatHaveBlockedPosts({
             uid: params.uid,
-            tids: tids,
-            blockedUids: blockedUids,
+            tids,
+            blockedUids,
             recentTids: categoryTids,
         });
 
@@ -172,15 +171,15 @@ module.exports = function (Topics) {
         counts.new = tidsByFilter.new.length;
 
         return {
-            counts: counts,
+            counts,
             tids: tidsByFilter[params.filter],
-            tidsByFilter: tidsByFilter,
+            tidsByFilter,
         };
     }
 
     async function getCategoryTids(params) {
         if (plugins.hooks.hasListeners('filter:topics.unread.getCategoryTids')) {
-            const result = await plugins.hooks.fire('filter:topics.unread.getCategoryTids', { params: params, tids: [] });
+            const result = await plugins.hooks.fire('filter:topics.unread.getCategoryTids', { params, tids: [] });
             return result.tids;
         }
         if (params.filter === 'watched') {
@@ -252,7 +251,7 @@ module.exports = function (Topics) {
         if (!uid || parseInt(uid, 10) <= 0) {
             return;
         }
-        const results = await Topics.getUnreadTids({ uid: uid, count: true });
+        const results = await Topics.getUnreadTids({ uid, count: true });
         require('../socket.io').in(`uid_${uid}`).emit('event:unread.updateCount', {
             unreadTopicCount: results[''],
             unreadNewTopicCount: results.new,
@@ -299,7 +298,7 @@ module.exports = function (Topics) {
         const cids = _.uniq(topicData.map(t => t && t.cid).filter(Boolean));
         await categories.markAsRead(cids, uid);
 
-        plugins.hooks.fire('action:topics.markAsRead', { uid: uid, tids: tids });
+        plugins.hooks.fire('action:topics.markAsRead', { uid, tids });
         return true;
     };
 
@@ -341,7 +340,7 @@ module.exports = function (Topics) {
             const read = !tids_unread[index] &&
                 (topicScores[index] < cutoff ||
                 !!(userScores[index] && userScores[index] >= topicScores[index]));
-            return { tid: tid, read: read, index: index };
+            return { tid, read, index };
         });
 
         return await async.map(result, async (data) => {
@@ -351,7 +350,7 @@ module.exports = function (Topics) {
             const hasUnblockedUnread = await doesTidHaveUnblockedUnreadPosts(data.tid, {
                 topicTimestamp: topicScores[data.index],
                 userLastReadTimestamp: userScores[data.index],
-                blockedUids: blockedUids,
+                blockedUids,
             });
             if (!hasUnblockedUnread) {
                 data.read = true;

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const path = require('path');
@@ -126,7 +125,7 @@ Upgrade.process = async function (files, skipCount) {
     ]);
 
     for (const file of files) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         const scriptExport = require(file);
         const date = new Date(scriptExport.timestamp);
         const version = path.dirname(file).split('/').pop();
@@ -136,7 +135,7 @@ Upgrade.process = async function (files, skipCount) {
             total: 0,
             incr: Upgrade.incrementProgress,
             script: scriptExport,
-            date: date,
+            date,
         };
 
         process.stdout.write(`${chalk.white('  → ') + chalk.gray(`[${[date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate()].join('/')}] `) + scriptExport.name}...`);
@@ -159,7 +158,7 @@ Upgrade.process = async function (files, skipCount) {
         const upgradeStart = Date.now();
         try {
             await scriptExport.method.bind({
-                progress: progress,
+                progress,
             })();
         } catch (err) {
             console.error('Error occurred');

--- a/src/upgrades/1.0.0/chat_room_hashes.js
+++ b/src/upgrades/1.0.0/chat_room_hashes.js
@@ -3,7 +3,6 @@
 const async = require('async');
 const db = require('../../database');
 
-
 module.exports = {
     name: 'Chat room hashes',
     timestamp: Date.UTC(2015, 11, 23),

--- a/src/upgrades/1.0.0/chat_upgrade.js
+++ b/src/upgrades/1.0.0/chat_upgrade.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const winston = require('winston');
 const db = require('../../database');

--- a/src/upgrades/1.0.0/social_post_sharing.js
+++ b/src/upgrades/1.0.0/social_post_sharing.js
@@ -3,7 +3,6 @@
 const async = require('async');
 const db = require('../../database');
 
-
 module.exports = {
     name: 'Social: Post Sharing',
     timestamp: Date.UTC(2016, 1, 25),

--- a/src/upgrades/1.0.0/theme_to_active_plugins.js
+++ b/src/upgrades/1.0.0/theme_to_active_plugins.js
@@ -2,7 +2,6 @@
 
 const db = require('../../database');
 
-
 module.exports = {
     name: 'Adding theme to active plugins sorted set',
     timestamp: Date.UTC(2015, 11, 23),

--- a/src/upgrades/1.0.0/user_best_posts.js
+++ b/src/upgrades/1.0.0/user_best_posts.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const winston = require('winston');
 const db = require('../../database');
@@ -27,7 +26,7 @@ module.exports = {
                 });
             }, next);
         }, {
-            progress: progress,
+            progress,
         }, callback);
     },
 };

--- a/src/upgrades/1.0.0/users_notvalidated.js
+++ b/src/upgrades/1.0.0/users_notvalidated.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const winston = require('winston');
 const db = require('../../database');

--- a/src/upgrades/1.1.0/dismiss_flags_from_deleted_topics.js
+++ b/src/upgrades/1.1.0/dismiss_flags_from_deleted_topics.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const winston = require('winston');
 const db = require('../../database');
 

--- a/src/upgrades/1.1.0/group_title_update.js
+++ b/src/upgrades/1.1.0/group_title_update.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const winston = require('winston');
 const db = require('../../database');

--- a/src/upgrades/1.1.0/separate_upvote_downvote.js
+++ b/src/upgrades/1.1.0/separate_upvote_downvote.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const winston = require('winston');
 const db = require('../../database');
@@ -48,7 +47,7 @@ module.exports = {
                 }, next);
             }, next);
         }, {
-            progress: progress,
+            progress,
         }, callback);
     },
 };

--- a/src/upgrades/1.1.0/user_post_count_per_tid.js
+++ b/src/upgrades/1.1.0/user_post_count_per_tid.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const winston = require('winston');
 const db = require('../../database');

--- a/src/upgrades/1.1.1/remove_negative_best_posts.js
+++ b/src/upgrades/1.1.1/remove_negative_best_posts.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const winston = require('winston');
 const db = require('../../database');

--- a/src/upgrades/1.1.1/upload_privileges.js
+++ b/src/upgrades/1.1.1/upload_privileges.js
@@ -3,7 +3,6 @@
 const async = require('async');
 const db = require('../../database');
 
-
 module.exports = {
     name: 'Giving upload privileges',
     timestamp: Date.UTC(2016, 6, 12),

--- a/src/upgrades/1.10.0/hash_recent_ip_addresses.js
+++ b/src/upgrades/1.10.0/hash_recent_ip_addresses.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const crypto = require('crypto');
 const nconf = require('nconf');

--- a/src/upgrades/1.10.0/post_history_privilege.js
+++ b/src/upgrades/1.10.0/post_history_privilege.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 
 const privileges = require('../../privileges');

--- a/src/upgrades/1.10.2/fix_category_post_zsets.js
+++ b/src/upgrades/1.10.2/fix_category_post_zsets.js
@@ -25,7 +25,7 @@ module.exports = {
             progress.incr(postData.length);
         }, {
             batch: 500,
-            progress: progress,
+            progress,
             withScores: true,
         });
     },

--- a/src/upgrades/1.10.2/fix_category_topic_zsets.js
+++ b/src/upgrades/1.10.2/fix_category_topic_zsets.js
@@ -24,7 +24,7 @@ module.exports = {
                 await topics.updateLastPostTimeFromLastPid(tid);
             }
         }, {
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.10.2/upgrade_bans_to_hashes.js
+++ b/src/upgrades/1.10.2/upgrade_bans_to_hashes.js
@@ -29,14 +29,14 @@ module.exports = {
                         Date.now()
                     );
                     const banKey = `uid:${uid}:ban:${banTimestamp}`;
-                    await addBan(uid, banKey, { uid: uid, timestamp: banTimestamp });
+                    await addBan(uid, banKey, { uid, timestamp: banTimestamp });
                 } else if (bans.length) {
                     // process ban history
                     for (const ban of bans) {
                         const reasonData = reasons.find(reasonData => reasonData.score === ban.score);
                         const banKey = `uid:${uid}:ban:${ban.score}`;
                         const data = {
-                            uid: uid,
+                            uid,
                             timestamp: ban.score,
                             expire: parseInt(ban.value, 10),
                         };

--- a/src/upgrades/1.12.0/category_watch_state.js
+++ b/src/upgrades/1.12.0/category_watch_state.js
@@ -26,7 +26,7 @@ module.exports = {
                 }
             }
         }, {
-            progress: progress,
+            progress,
             batch: 500,
         });
 

--- a/src/upgrades/1.12.1/post_upload_sizes.js
+++ b/src/upgrades/1.12.1/post_upload_sizes.js
@@ -17,7 +17,7 @@ module.exports = {
             progress.incr(pids.length);
         }, {
             batch: 100,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.12.3/user_pid_sets.js
+++ b/src/upgrades/1.12.3/user_pid_sets.js
@@ -1,6 +1,4 @@
-
 'use strict';
-
 
 const db = require('../../database');
 const batch = require('../../batch');
@@ -29,7 +27,7 @@ module.exports = {
             });
             await db.sortedSetAddBulk(bulk);
         }, {
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.13.0/clean_flag_byCid.js
+++ b/src/upgrades/1.13.0/clean_flag_byCid.js
@@ -21,7 +21,7 @@ module.exports = {
 
             await db.sortedSetRemoveBulk(bulkRemove);
         }, {
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.13.0/clean_post_topic_hash.js
+++ b/src/upgrades/1.13.0/clean_post_topic_hash.js
@@ -51,7 +51,7 @@ async function cleanPost(progress) {
         }));
     }, {
         batch: 500,
-        progress: progress,
+        progress,
     });
 }
 
@@ -90,6 +90,6 @@ async function cleanTopic(progress) {
         }));
     }, {
         batch: 500,
-        progress: progress,
+        progress,
     });
 }

--- a/src/upgrades/1.13.0/cleanup_old_notifications.js
+++ b/src/upgrades/1.13.0/cleanup_old_notifications.js
@@ -45,7 +45,7 @@ module.exports = {
             }));
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.13.3/fix_users_sorted_sets.js
+++ b/src/upgrades/1.13.3/fix_users_sorted_sets.js
@@ -53,7 +53,7 @@ module.exports = {
                 }
             }));
         }, {
-            progress: progress,
+            progress,
             batch: 500,
         });
 

--- a/src/upgrades/1.14.1/readd_deleted_recent_topics.js
+++ b/src/upgrades/1.14.1/readd_deleted_recent_topics.js
@@ -49,7 +49,7 @@ module.exports = {
                 topicData.map(t => t.tid)
             );
         }, {
-            progress: progress,
+            progress,
             batchSize: 500,
         });
     },

--- a/src/upgrades/1.15.0/add_target_uid_to_flags.js
+++ b/src/upgrades/1.15.0/add_target_uid_to_flags.js
@@ -30,7 +30,7 @@ module.exports = {
                 }
             }
         }, {
-            progress: progress,
+            progress,
             batch: 500,
         });
     },

--- a/src/upgrades/1.15.0/consolidate_flags.js
+++ b/src/upgrades/1.15.0/consolidate_flags.js
@@ -39,7 +39,7 @@ module.exports = {
                 await Promise.all(methods.map(async method => method()));
             }));
         }, {
-            progress: progress,
+            progress,
             batch: 500,
         });
     },

--- a/src/upgrades/1.15.0/remove_flag_reporters_zset.js
+++ b/src/upgrades/1.15.0/remove_flag_reporters_zset.js
@@ -27,7 +27,7 @@ module.exports = {
             }));
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.15.0/topic_poster_count.js
+++ b/src/upgrades/1.15.0/topic_poster_count.js
@@ -23,7 +23,7 @@ module.exports = {
             }
             await db.setObjectBulk(bulkSet);
         }, {
-            progress: progress,
+            progress,
             batchSize: 500,
         });
     },

--- a/src/upgrades/1.15.4/clear_purged_replies.js
+++ b/src/upgrades/1.15.4/clear_purged_replies.js
@@ -26,7 +26,7 @@ module.exports = {
             const repliesToDelete = _.uniq(toPids.filter((pid, index) => !exists[index]));
             await db.deleteAll(repliesToDelete.map(pid => `pid:${pid}:replies`));
         }, {
-            progress: progress,
+            progress,
             batchSize: 500,
         });
     },

--- a/src/upgrades/1.16.0/category_tags.js
+++ b/src/upgrades/1.16.0/category_tags.js
@@ -13,7 +13,7 @@ module.exports = {
 
         async function getTopicsTags(tids) {
             return await db.getSetsMembers(
-                tids.map(tid => `topic:${tid}:tags`),
+                tids.map(tid => `topic:${tid}:tags`)
             );
         }
 
@@ -40,7 +40,7 @@ module.exports = {
             progress.incr(tids.length);
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.16.0/migrate_thumbs.js
+++ b/src/upgrades/1.16.0/migrate_thumbs.js
@@ -36,7 +36,7 @@ module.exports = {
             }));
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.17.0/banned_users_group.js
+++ b/src/upgrades/1.17.0/banned_users_group.js
@@ -48,7 +48,6 @@ module.exports = {
             progress: this.progress,
         });
 
-
         const bannedCount = await db.sortedSetCard('group:banned-users:members');
         const registeredCount = await db.sortedSetCard('group:registered-users:members');
         const verifiedCount = await db.sortedSetCard('group:verified-users:members');

--- a/src/upgrades/1.17.0/category_name_zset.js
+++ b/src/upgrades/1.17.0/category_name_zset.js
@@ -22,7 +22,7 @@ module.exports = {
             progress.incr(cids.length);
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.17.0/subcategories_per_page.js
+++ b/src/upgrades/1.17.0/subcategories_per_page.js
@@ -17,7 +17,7 @@ module.exports = {
             progress.incr(cids.length);
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.17.0/topic_thumb_count.js
+++ b/src/upgrades/1.17.0/topic_thumb_count.js
@@ -16,13 +16,13 @@ module.exports = {
             const tidToCount = _.zipObject(tids, counts);
             const tidsWithThumbs = tids.filter((t, i) => counts[i] > 0);
             await db.setObjectBulk(
-                tidsWithThumbs.map(tid => [`topic:${tid}`, { numThumbs: tidToCount[tid] }]),
+                tidsWithThumbs.map(tid => [`topic:${tid}`, { numThumbs: tidToCount[tid] }])
             );
 
             progress.incr(tids.length);
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.18.0/topic_tags_refactor.js
+++ b/src/upgrades/1.18.0/topic_tags_refactor.js
@@ -11,7 +11,7 @@ module.exports = {
 
         async function getTopicsTags(tids) {
             return await db.getSetsMembers(
-                tids.map(tid => `topic:${tid}:tags`),
+                tids.map(tid => `topic:${tid}:tags`)
             );
         }
 
@@ -19,19 +19,19 @@ module.exports = {
             const tags = await getTopicsTags(tids);
 
             const topicsWithTags = tids.map((tid, i) => {
-                const topic = { tid: tid };
+                const topic = { tid };
                 topic.tags = tags[i];
                 return topic;
             }).filter(t => t && t.tags.length);
 
             await db.setObjectBulk(
-                topicsWithTags.map(t => [`topic:${t.tid}`, { tags: t.tags.join(',') }]),
+                topicsWithTags.map(t => [`topic:${t.tid}`, { tags: t.tags.join(',') }])
             );
             await db.deleteAll(tids.map(tid => `topic:${tid}:tags`));
             progress.incr(tids.length);
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.18.4/category_topics_views.js
+++ b/src/upgrades/1.18.4/category_topics_views.js
@@ -17,7 +17,7 @@ module.exports = {
             progress.incr(tids.length);
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.19.3/fix_user_uploads_zset.js
+++ b/src/upgrades/1.19.3/fix_user_uploads_zset.js
@@ -32,12 +32,12 @@ module.exports = {
                     );
                     // Add uid to the upload's hash object
                     uploads = await db.getSortedSetMembers(key);
-                    await db.setObjectBulk(uploads.map(relativePath => [`upload:${md5(relativePath)}`, { uid: uid }]));
+                    await db.setObjectBulk(uploads.map(relativePath => [`upload:${md5(relativePath)}`, { uid }]));
                 }
             }));
         }, {
             batch: 500,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.19.3/rename_post_upload_hashes.js
+++ b/src/upgrades/1.19.3/rename_post_upload_hashes.js
@@ -57,7 +57,7 @@ module.exports = {
             }
         }, {
             batch: 100,
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.2.0/category_recent_tids.js
+++ b/src/upgrades/1.2.0/category_recent_tids.js
@@ -3,7 +3,6 @@
 const async = require('async');
 const db = require('../../database');
 
-
 module.exports = {
     name: 'Category recent tids',
     timestamp: Date.UTC(2016, 8, 22),

--- a/src/upgrades/1.3.0/favourites_to_bookmarks.js
+++ b/src/upgrades/1.3.0/favourites_to_bookmarks.js
@@ -21,7 +21,7 @@ module.exports = {
                     await db.deleteObjectField(`post:${id}`, 'reputation');
                 }));
             }, {
-                progress: progress,
+                progress,
             });
         }
 

--- a/src/upgrades/1.3.0/sorted_sets_for_post_replies.js
+++ b/src/upgrades/1.3.0/sorted_sets_for_post_replies.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const winston = require('winston');
 const db = require('../../database');
@@ -33,7 +32,7 @@ module.exports = {
                 }, next);
             });
         }, {
-            progress: progress,
+            progress,
         }, callback);
     },
 };

--- a/src/upgrades/1.4.0/global_and_user_language_keys.js
+++ b/src/upgrades/1.4.0/global_and_user_language_keys.js
@@ -31,7 +31,7 @@ module.exports = {
                 }
             }));
         }, {
-            progress: progress,
+            progress,
         });
     },
 };

--- a/src/upgrades/1.4.0/sorted_set_for_pinned_topics.js
+++ b/src/upgrades/1.4.0/sorted_set_for_pinned_topics.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const winston = require('winston');
 const db = require('../../database');

--- a/src/upgrades/1.4.4/config_urls_update.js
+++ b/src/upgrades/1.4.4/config_urls_update.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const db = require('../../database');
 
 module.exports = {

--- a/src/upgrades/1.4.4/sound_settings.js
+++ b/src/upgrades/1.4.4/sound_settings.js
@@ -3,7 +3,6 @@
 const async = require('async');
 const db = require('../../database');
 
-
 module.exports = {
     name: 'Update global and user sound settings',
     timestamp: Date.UTC(2017, 1, 25),

--- a/src/upgrades/1.5.0/flags_refactor.js
+++ b/src/upgrades/1.5.0/flags_refactor.js
@@ -35,7 +35,7 @@ module.exports = {
                             await flags.update(flagObj.flagId, 1, {
                                 state: post['flag:state'],
                                 assignee: post['flag:assignee'],
-                                datetime: datetime,
+                                datetime,
                             });
                         }
                         if (post.hasOwnProperty('flag:notes') && post['flag:notes'].length) {

--- a/src/upgrades/1.5.0/moderation_history_refactor.js
+++ b/src/upgrades/1.5.0/moderation_history_refactor.js
@@ -4,7 +4,6 @@ const async = require('async');
 const db = require('../../database');
 const batch = require('../../batch');
 
-
 module.exports = {
     name: 'Update moderation notes to zset',
     timestamp: Date.UTC(2017, 2, 22),

--- a/src/upgrades/1.5.0/post_votes_zset.js
+++ b/src/upgrades/1.5.0/post_votes_zset.js
@@ -3,7 +3,6 @@
 const async = require('async');
 const db = require('../../database');
 
-
 module.exports = {
     name: 'New sorted set posts:votes',
     timestamp: Date.UTC(2017, 1, 27),

--- a/src/upgrades/1.5.1/rename_mods_group.js
+++ b/src/upgrades/1.5.1/rename_mods_group.js
@@ -6,7 +6,6 @@ const winston = require('winston');
 const batch = require('../../batch');
 const groups = require('../../groups');
 
-
 module.exports = {
     name: 'rename user mod privileges group',
     timestamp: Date.UTC(2017, 4, 26),
@@ -27,7 +26,7 @@ module.exports = {
                 });
             }, next);
         }, {
-            progress: progress,
+            progress,
         }, callback);
     },
 };

--- a/src/upgrades/1.5.2/rss_token_wipe.js
+++ b/src/upgrades/1.5.2/rss_token_wipe.js
@@ -16,7 +16,7 @@ module.exports = {
                 db.deleteObjectField(`user:${uid}`, 'rss_token', next);
             }, next);
         }, {
-            progress: progress,
+            progress,
         }, callback);
     },
 };

--- a/src/upgrades/1.5.2/tags_privilege.js
+++ b/src/upgrades/1.5.2/tags_privilege.js
@@ -16,7 +16,7 @@ module.exports = {
                 privileges.categories.give(['groups:topics:tag'], cid, 'registered-users', next);
             }, next);
         }, {
-            progress: progress,
+            progress,
         }, callback);
     },
 };

--- a/src/upgrades/1.6.0/generate-email-logo.js
+++ b/src/upgrades/1.6.0/generate-email-logo.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const path = require('path');
 const nconf = require('nconf');

--- a/src/upgrades/1.6.0/ipblacklist-fix.js
+++ b/src/upgrades/1.6.0/ipblacklist-fix.js
@@ -8,6 +8,6 @@ module.exports = {
     method: async function () {
         const rules = await db.get('ip-blacklist-rules');
         await db.delete('ip-blacklist-rules');
-        await db.setObject('ip-blacklist-rules', { rules: rules });
+        await db.setObject('ip-blacklist-rules', { rules });
     },
 };

--- a/src/upgrades/1.7.1/notification-settings.js
+++ b/src/upgrades/1.7.1/notification-settings.js
@@ -24,7 +24,7 @@ module.exports = {
                 await db.deleteObjectFields(`user:${uid}:settings`, ['sendChatNotifications', 'sendPostNotifications']);
             }));
         }, {
-            progress: progress,
+            progress,
             batch: 500,
         });
     },

--- a/src/upgrades/1.7.3/topic_votes.js
+++ b/src/upgrades/1.7.3/topic_votes.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const batch = require('../../batch');
 const db = require('../../database');
 
@@ -20,8 +19,8 @@ module.exports = {
                         const upvotes = parseInt(postData.upvotes, 10) || 0;
                         const downvotes = parseInt(postData.downvotes, 10) || 0;
                         const data = {
-                            upvotes: upvotes,
-                            downvotes: downvotes,
+                            upvotes,
+                            downvotes,
                         };
                         const votes = upvotes - downvotes;
                         await Promise.all([
@@ -35,7 +34,7 @@ module.exports = {
                 }
             }));
         }, {
-            progress: progress,
+            progress,
             batch: 500,
         });
     },

--- a/src/upgrades/1.7.4/chat_privilege.js
+++ b/src/upgrades/1.7.4/chat_privilege.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const groups = require('../../groups');
 
 module.exports = {

--- a/src/upgrades/1.7.4/fix_moved_topics_byvotes.js
+++ b/src/upgrades/1.7.4/fix_moved_topics_byvotes.js
@@ -24,7 +24,7 @@ module.exports = {
                 }
             }));
         }, {
-            progress: progress,
+            progress,
             batch: 500,
         });
     },

--- a/src/upgrades/1.7.4/fix_user_topics_per_category.js
+++ b/src/upgrades/1.7.4/fix_user_topics_per_category.js
@@ -22,7 +22,7 @@ module.exports = {
                 }
             }));
         }, {
-            progress: progress,
+            progress,
             batch: 500,
         });
     },

--- a/src/upgrades/1.7.4/global_upload_privilege.js
+++ b/src/upgrades/1.7.4/global_upload_privilege.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const groups = require('../../groups');
 const privileges = require('../../privileges');

--- a/src/upgrades/1.7.4/vote_privilege.js
+++ b/src/upgrades/1.7.4/vote_privilege.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 
 const privileges = require('../../privileges');

--- a/src/upgrades/1.8.0/give_spiders_privileges.js
+++ b/src/upgrades/1.8.0/give_spiders_privileges.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const async = require('async');
 const groups = require('../../groups');
 const privileges = require('../../privileges');

--- a/src/upgrades/1.8.1/diffs_zset_to_listhash.js
+++ b/src/upgrades/1.8.1/diffs_zset_to_listhash.js
@@ -4,7 +4,6 @@ const async = require('async');
 const db = require('../../database');
 const batch = require('../../batch');
 
-
 module.exports = {
     name: 'Reformatting post diffs to be stored in lists and hash instead of single zset',
     timestamp: Date.UTC(2018, 2, 15),
@@ -29,7 +28,7 @@ module.exports = {
                             async.apply(db.delete.bind(db), `post:${pid}:diffs`),
                             async.apply(db.listPrepend.bind(db), `post:${pid}:diffs`, diff.score),
                             async.apply(db.setObject.bind(db), `diff:${pid}.${diff.score}`, {
-                                pid: pid,
+                                pid,
                                 patch: diff.value,
                             }),
                         ], next);
@@ -51,7 +50,7 @@ module.exports = {
                 return next();
             });
         }, {
-            progress: progress,
+            progress,
         }, callback);
     },
 };

--- a/src/user/admin.js
+++ b/src/user/admin.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const fs = require('fs');

--- a/src/user/auth.js
+++ b/src/user/auth.js
@@ -33,8 +33,8 @@ module.exports = function (User) {
         await db.pexpire(`lockout:${uid}`, duration);
         await events.log({
             type: 'account-locked',
-            uid: uid,
-            ip: ip,
+            uid,
+            ip,
         });
         throw new Error('[[error:account-locked]]');
     };

--- a/src/user/bans.js
+++ b/src/user/bans.js
@@ -12,8 +12,8 @@ module.exports = function (User) {
     User.bans = {};
 
     User.bans.ban = async function (uid, until, reason) {
-        // "until" (optional) is unix timestamp in milliseconds
-        // "reason" (optional) is a string
+    // "until" (optional) is unix timestamp in milliseconds
+    // "reason" (optional) is a string
         until = until || 0;
         reason = reason || '';
 
@@ -26,7 +26,7 @@ module.exports = function (User) {
 
         const banKey = `uid:${uid}:ban:${now}`;
         const banData = {
-            uid: uid,
+            uid,
             timestamp: now,
             expire: until > now ? until : 0,
         };
@@ -54,9 +54,9 @@ module.exports = function (User) {
 
         const data = {
             subject: `[[email:banned.subject, ${siteTitle}]]`,
-            username: username,
+            username,
             until: until ? (new Date(until)).toUTCString().replace(/,/g, '\\,') : false,
-            reason: reason,
+            reason,
         };
         await emailer.send('banned', uid, data).catch(err => winston.error(`[emailer.send] ${err.stack}`));
 
@@ -107,7 +107,7 @@ module.exports = function (User) {
     };
 
     User.bans.unbanIfExpired = async function (uids) {
-        // loading user data will unban if it has expired -barisu
+    // loading user data will unban if it has expired -barisu
         const userData = await User.getUsersFields(uids, ['banned:expire']);
         return User.bans.calcExpiredFromUserData(userData);
     };

--- a/src/user/blocks.js
+++ b/src/user/blocks.js
@@ -22,7 +22,7 @@ module.exports = function (User) {
     };
 
     User.blocks.can = async function (callerUid, blockerUid, blockeeUid, type) {
-        // Guests can't block
+    // Guests can't block
         if (blockerUid === 0 || blockeeUid === 0) {
             throw new Error('[[error:cannot-block-guest]]');
         } else if (blockerUid === blockeeUid) {
@@ -64,7 +64,7 @@ module.exports = function (User) {
         await db.sortedSetAdd(`uid:${uid}:blocked_uids`, Date.now(), targetUid);
         await User.incrementUserFieldBy(uid, 'blocksCount', 1);
         User.blocks._cache.del(parseInt(uid, 10));
-        plugins.hooks.fire('action:user.blocks.add', { uid: uid, targetUid: targetUid });
+        plugins.hooks.fire('action:user.blocks.add', { uid, targetUid });
     };
 
     User.blocks.remove = async function (targetUid, uid) {
@@ -72,7 +72,7 @@ module.exports = function (User) {
         await db.sortedSetRemove(`uid:${uid}:blocked_uids`, targetUid);
         await User.decrementUserFieldBy(uid, 'blocksCount', 1);
         User.blocks._cache.del(parseInt(uid, 10));
-        plugins.hooks.fire('action:user.blocks.remove', { uid: uid, targetUid: targetUid });
+        plugins.hooks.fire('action:user.blocks.remove', { uid, targetUid });
     };
 
     User.blocks.applyChecks = async function (type, targetUid, uid) {
@@ -90,8 +90,8 @@ module.exports = function (User) {
     };
 
     User.blocks.filter = async function (uid, property, set) {
-        // Given whatever is passed in, iterates through it, and removes entries made by blocked uids
-        // property is optional
+    // Given whatever is passed in, iterates through it, and removes entries made by blocked uids
+    // property is optional
         if (Array.isArray(property) && typeof set === 'undefined') {
             set = property;
             property = 'uid';
@@ -106,7 +106,7 @@ module.exports = function (User) {
         const blockedSet = new Set(blocked_uids);
 
         set = set.filter(item => !blockedSet.has(parseInt(isPlain ? item : (item && item[property]), 10)));
-        const data = await plugins.hooks.fire('filter:user.blocks.filter', { set: set, property: property, uid: uid, blockedSet: blockedSet });
+        const data = await plugins.hooks.fire('filter:user.blocks.filter', { set, property, uid, blockedSet });
 
         return data.set;
     };

--- a/src/user/categories.js
+++ b/src/user/categories.js
@@ -39,8 +39,8 @@ module.exports = function (User) {
         }
         const cids = await User.getCategoriesByStates(uid, [categories.watchStates.ignoring]);
         const result = await plugins.hooks.fire('filter:user.getIgnoredCategories', {
-            uid: uid,
-            cids: cids,
+            uid,
+            cids,
         });
         return result.cids;
     };
@@ -51,8 +51,8 @@ module.exports = function (User) {
         }
         const cids = await User.getCategoriesByStates(uid, [categories.watchStates.watching]);
         const result = await plugins.hooks.fire('filter:user.getWatchedCategories', {
-            uid: uid,
-            cids: cids,
+            uid,
+            cids,
         });
         return result.cids;
     };

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -74,7 +74,7 @@ module.exports = function (User) {
             userData.userslug = slugify(renamedUsername);
         }
 
-        const results = await plugins.hooks.fire('filter:user.create', { user: userData, data: data });
+        const results = await plugins.hooks.fire('filter:user.create', { user: userData, data });
         userData = results.user;
 
         const uid = await db.incrObjectField('global', 'nextUid');
@@ -122,7 +122,7 @@ module.exports = function (User) {
         if (userNameChanged) {
             await User.notifications.sendNameChangeNotification(userData.uid, userData.username);
         }
-        plugins.hooks.fire('action:user.create', { user: userData, data: data });
+        plugins.hooks.fire('action:user.create', { user: userData, data });
         return userData.uid;
     }
 

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -62,7 +62,7 @@ module.exports = function (User) {
         const uniqueUids = _.uniq(uids).filter(uid => uid > 0);
 
         const results = await plugins.hooks.fire('filter:user.whitelistFields', {
-            uids: uids,
+            uids,
             whitelist: fieldWhitelist.slice(),
         });
         if (!fields.length) {
@@ -72,13 +72,11 @@ module.exports = function (User) {
             fields = fields.filter(value => value !== 'password');
         }
 
-
-
         const users = await db.getObjectsFields(uniqueUids.map(uid => `user:${uid}`), fields);
         const result = await plugins.hooks.fire('filter:user.getFields', {
             uids: uniqueUids,
-            users: users,
-            fields: fields,
+            users,
+            fields,
         });
         result.users.forEach((user, index) => {
             if (uniqueUids[index] > 0 && !user.uid) {
@@ -365,7 +363,7 @@ module.exports = function (User) {
 
     async function incrDecrUserFieldBy(uid, field, value, type) {
         const newValue = await db.incrObjectFieldBy(`user:${uid}`, field, value);
-        plugins.hooks.fire('action:user.set', { uid: uid, field: field, value: newValue, type: type });
+        plugins.hooks.fire('action:user.set', { uid, field, value: newValue, type });
         return newValue;
     }
 };

--- a/src/user/delete.js
+++ b/src/user/delete.js
@@ -98,7 +98,7 @@ module.exports = function (User) {
             throw new Error('[[error:no-user]]');
         }
 
-        await plugins.hooks.fire('static:user.delete', { uid: uid, userData: userData });
+        await plugins.hooks.fire('static:user.delete', { uid, userData });
         await deleteVotes(uid);
         await deleteChats(uid);
         await User.auth.revokeAllSessions(uid);

--- a/src/user/digest.js
+++ b/src/user/digest.js
@@ -33,7 +33,7 @@ Digest.execute = async function (payload) {
         winston.info(`[user/jobs] Digest (${payload.interval}) scheduling completed (${subscribers.length} subscribers). Sending emails; this may take some time...`);
         await Digest.send({
             interval: payload.interval,
-            subscribers: subscribers,
+            subscribers,
         });
         winston.info(`[user/jobs] Digest (${payload.interval}) complete.`);
     } catch (err) {
@@ -74,8 +74,8 @@ Digest.getSubscribers = async function (interval) {
     });
 
     const results = await plugins.hooks.fire('filter:digest.subscribers', {
-        interval: interval,
-        subscribers: subscribers,
+        interval,
+        subscribers,
     });
     return results.subscribers;
 };
@@ -150,7 +150,7 @@ Digest.getDeliveryTimes = async (start, stop) => {
     }
 
     const [scores, settings] = await Promise.all([
-        // Grab the last time a digest was successfully delivered to these uids
+    // Grab the last time a digest was successfully delivered to these uids
         db.sortedSetScores('digest:delivery', uids),
         // Get users' digest settings
         Digest.getUsersInterval(uids),
@@ -166,16 +166,16 @@ Digest.getDeliveryTimes = async (start, stop) => {
 
     return {
         users: userData,
-        count: count,
+        count,
     };
 };
 
 async function getTermTopics(term, uid) {
     const data = await topics.getSortedTopics({
-        uid: uid,
+        uid,
         start: 0,
         stop: 199,
-        term: term,
+        term,
         sort: 'votes',
         teaserPost: 'first',
     });
@@ -202,7 +202,8 @@ async function getTermTopics(term, uid) {
             }
             // Fix relative paths in topic data
             const user = topicObj.hasOwnProperty('teaser') && topicObj.teaser && topicObj.teaser.user ?
-                topicObj.teaser.user : topicObj.user;
+                topicObj.teaser.user :
+                topicObj.user;
             if (user && user.picture && utils.isRelativeUrl(user.picture)) {
                 user.picture = baseUrl + user.picture;
             }

--- a/src/user/email.js
+++ b/src/user/email.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const nconf = require('nconf');
@@ -138,7 +137,7 @@ UserEmail.sendValidationEmail = async function (uid, options) {
 
     await db.setObject(`confirm:${confirm_code}`, {
         email: options.email.toLowerCase(),
-        uid: uid,
+        uid,
     });
     await db.pexpire(`confirm:${confirm_code}`, emailConfirmExpiry * 24 * 60 * 60 * 1000);
 
@@ -151,7 +150,7 @@ UserEmail.sendValidationEmail = async function (uid, options) {
     });
 
     if (plugins.hooks.hasListeners('action:user.verify')) {
-        plugins.hooks.fire('action:user.verify', { uid: uid, data: data });
+        plugins.hooks.fire('action:user.verify', { uid, data });
     } else {
         await emailer.send(data.template, uid, data);
     }
@@ -208,5 +207,5 @@ UserEmail.confirmByUid = async function (uid) {
         user.email.expireValidation(uid),
         user.reset.cleanByUid(uid),
     ]);
-    await plugins.hooks.fire('action:user.email.confirmed', { uid: uid, email: currentEmail });
+    await plugins.hooks.fire('action:user.email.confirmed', { uid, email: currentEmail });
 };

--- a/src/user/follow.js
+++ b/src/user/follow.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const plugins = require('../plugins');
@@ -73,10 +72,10 @@ module.exports = function (User) {
         }
         const uids = await db.getSortedSetRevRange(`${type}:${uid}`, start, stop);
         const data = await plugins.hooks.fire(`filter:user.${type}`, {
-            uids: uids,
-            uid: uid,
-            start: start,
-            stop: stop,
+            uids,
+            uid,
+            start,
+            stop,
         });
         return await User.getUsers(data.uids, uid);
     }

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -69,10 +69,10 @@ User.getUsersFromSet = async function (set, uid, start, stop) {
 };
 
 User.getUsersWithFields = async function (uids, fields, uid) {
-    let results = await plugins.hooks.fire('filter:users.addFields', { fields: fields });
+    let results = await plugins.hooks.fire('filter:users.addFields', { fields });
     results.fields = _.uniq(results.fields);
     const userData = await User.getUsersFields(uids, results.fields);
-    results = await plugins.hooks.fire('filter:userlist.get', { users: userData, uid: uid });
+    results = await plugins.hooks.fire('filter:userlist.get', { users: userData, uid });
     return results.users;
 };
 

--- a/src/user/info.js
+++ b/src/user/info.js
@@ -10,7 +10,7 @@ const utils = require('../utils');
 
 module.exports = function (User) {
     User.getLatestBanInfo = async function (uid) {
-        // Simply retrieves the last record of the user's ban, even if they've been unbanned since then.
+    // Simply retrieves the last record of the user's ban, even if they've been unbanned since then.
         const record = await db.getSortedSetRevRange(`uid:${uid}:bans:timestamp`, 0, 0);
         if (!record.length) {
             throw new Error('no-ban-info');
@@ -19,7 +19,7 @@ module.exports = function (User) {
         const expire = parseInt(banInfo.expire, 10);
         const expire_readable = utils.toISOString(expire);
         return {
-            uid: uid,
+            uid,
             timestamp: banInfo.timestamp,
             banned_until: expire,
             expiry: expire, /* backward compatible alias */
@@ -59,9 +59,9 @@ module.exports = function (User) {
         ]);
 
         return {
-            flags: flags,
-            bans: bans,
-            mutes: mutes,
+            flags,
+            bans,
+            mutes,
         };
     };
 

--- a/src/user/interstitials.js
+++ b/src/user/interstitials.js
@@ -164,7 +164,7 @@ Interstitials.tou = async function (data) {
         throw new Error('[[error:invalid-data]]');
     }
     if (!meta.config.termsOfUse || data.userData.acceptTos) {
-        // no ToS or ToS accepted, nothing to do
+    // no ToS or ToS accepted, nothing to do
         return data;
     }
 

--- a/src/user/invite.js
+++ b/src/user/invite.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const async = require('async');
@@ -177,11 +176,11 @@ module.exports = function (User) {
         return {
             ...emailer._defaultPayload, // Append default data to this email payload
             site_title: title,
-            registerLink: registerLink,
-            subject: subject,
-            username: username,
+            registerLink,
+            subject,
+            username,
             template: 'invitation',
-            expireDays: expireDays,
+            expireDays,
         };
     }
 };

--- a/src/user/jobs.js
+++ b/src/user/jobs.js
@@ -29,11 +29,11 @@ module.exports = function (User) {
         jobs['reset.clean'] = new cronJob('0 0 * * *', User.reset.clean, null, true);
         winston.verbose('[user/jobs] Starting job (reset.clean)');
 
-        winston.verbose(`[user/jobs] jobs started`);
+        winston.verbose('[user/jobs] jobs started');
     };
 
     function startDigestJob(name, cronString, term) {
-        jobs[name] = new cronJob(cronString, (async () => {
+        jobs[name] = new cronJob(cronString, async () => {
             winston.verbose(`[user/jobs] Digest job (${name}) started.`);
             try {
                 if (name === 'digest.weekly') {
@@ -46,7 +46,7 @@ module.exports = function (User) {
             } catch (err) {
                 winston.error(err.stack);
             }
-        }), null, true);
+        }, null, true);
         winston.verbose(`[user/jobs] Starting job (${name})`);
     }
 

--- a/src/user/jobs/export-profile.js
+++ b/src/user/jobs/export-profile.js
@@ -69,16 +69,16 @@ process.on('message', async (msg) => {
         await fs.promises.writeFile(profilePath, JSON.stringify({
             user: userData,
             settings: userSettings,
-            ips: ips,
-            sessions: sessions,
-            usernames: usernames,
-            emails: emails,
+            ips,
+            sessions,
+            usernames,
+            emails,
             messages: chatData,
-            bookmarks: bookmarks,
-            watchedTopics: watchedTopics,
-            upvoted: upvoted,
-            downvoted: downvoted,
-            following: following,
+            bookmarks,
+            watchedTopics,
+            upvoted,
+            downvoted,
+            following,
         }, null, 4));
 
         await db.close();

--- a/src/user/notifications.js
+++ b/src/user/notifications.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const winston = require('winston');
@@ -28,7 +27,7 @@ UserNotifications.get = async function (uid) {
     return await plugins.hooks.fire('filter:user.notifications.get', {
         uid,
         read: read.filter(Boolean),
-        unread: unread,
+        unread,
     });
 };
 
@@ -99,7 +98,7 @@ UserNotifications.getNotifications = async function (nids, uid) {
     await deleteUserNids(deletedNids, uid);
     notificationData = await notifications.merge(notificationData);
     const result = await plugins.hooks.fire('filter:user.notifications.getNotifications', {
-        uid: uid,
+        uid,
         notifications: notificationData,
     });
     return result && result.notifications;
@@ -136,7 +135,7 @@ UserNotifications.getUnreadCount = async function (uid) {
 
     // Collapse any notifications with identical mergeIds
     let count = mergeIds.reduce((count, mergeId, idx, arr) => {
-        // A missing (null) mergeId means that notification is counted separately.
+    // A missing (null) mergeId means that notification is counted separately.
         if (mergeId === null || idx === arr.indexOf(mergeId)) {
             count += 1;
         }
@@ -207,7 +206,7 @@ UserNotifications.sendWelcomeNotification = async function (uid) {
     const path = meta.config.welcomeLink ? meta.config.welcomeLink : '#';
     const notifObj = await notifications.create({
         bodyShort: meta.config.welcomeNotification,
-        path: path,
+        path,
         nid: `welcome_${uid}`,
         from: meta.config.welcomeUid ? meta.config.welcomeUid : null,
     });

--- a/src/user/online.js
+++ b/src/user/online.js
@@ -29,7 +29,7 @@ module.exports = function (User) {
         }
         await db.sortedSetAdd('users:online', now, uid);
         topics.pushUnreadCount(uid);
-        plugins.hooks.fire('action:user.online', { uid: uid, timestamp: now });
+        plugins.hooks.fire('action:user.online', { uid, timestamp: now });
     };
 
     User.isOnline = async function (uid) {

--- a/src/user/password.js
+++ b/src/user/password.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const nconf = require('nconf');
 
 const db = require('../database');

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -24,7 +24,7 @@ module.exports = function (User) {
     };
 
     User.updateCoverPosition = async function (uid, position) {
-        // Reject anything that isn't two percentages
+    // Reject anything that isn't two percentages
         if (!/^[\d.]+%\s[\d.]+%$/.test(position)) {
             winston.warn(`[user/updateCoverPosition] Invalid position received: ${position}`);
             throw new Error('[[error:invalid-data]]');

--- a/src/user/posts.js
+++ b/src/user/posts.js
@@ -59,7 +59,7 @@ module.exports = function (User) {
     }
 
     User.onNewPostMade = async function (postData) {
-        // For scheduled posts, use "action" time. It'll be updated in related cron job when post is published
+    // For scheduled posts, use "action" time. It'll be updated in related cron job when post is published
         const lastposttime = postData.timestamp > Date.now() ? Date.now() : postData.timestamp;
 
         await Promise.all([

--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -27,9 +26,9 @@ module.exports = function (User) {
         const updateUid = data.uid;
 
         const result = await plugins.hooks.fire('filter:user.updateProfile', {
-            uid: uid,
-            data: data,
-            fields: fields,
+            uid,
+            data,
+            fields,
         });
         fields = result.fields;
         data = result.data;
@@ -60,10 +59,10 @@ module.exports = function (User) {
         }
 
         plugins.hooks.fire('action:user.updateProfile', {
-            uid: uid,
-            data: data,
-            fields: fields,
-            oldData: oldData,
+            uid,
+            data,
+            fields,
+            oldData,
         });
 
         return await User.getUserFields(updateUid, [
@@ -330,6 +329,6 @@ module.exports = function (User) {
             User.email.expireValidation(data.uid),
         ]);
 
-        plugins.hooks.fire('action:password.change', { uid: uid, targetUid: data.uid });
+        plugins.hooks.fire('action:password.change', { uid, targetUid: data.uid });
     };
 };

--- a/src/user/reset.js
+++ b/src/user/reset.js
@@ -58,7 +58,7 @@ UserReset.send = async function (email) {
         reset_link: `${nconf.get('url')}/reset/${code}`,
         subject: '[[email:password-reset-requested]]',
         template: 'reset',
-        uid: uid,
+        uid,
     }).catch(err => winston.error(`[emailer.send] ${err.stack}`));
 
     return code;

--- a/src/user/search.js
+++ b/src/user/search.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const _ = require('lodash');
@@ -24,7 +23,6 @@ module.exports = function (User) {
         unverified: ['email:confirmed'],
     };
 
-
     User.search = async function (data) {
         const query = data.query || '';
         const searchBy = data.searchBy || 'username';
@@ -45,7 +43,7 @@ module.exports = function (User) {
         }
 
         uids = await filterAndSortUids(uids, data);
-        const result = await plugins.hooks.fire('filter:users.search', { uids: uids, uid: uid });
+        const result = await plugins.hooks.fire('filter:users.search', { uids, uid });
         uids = result.uids;
 
         const searchResult = {

--- a/src/user/settings.js
+++ b/src/user/settings.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const validator = require('validator');
@@ -36,7 +35,7 @@ module.exports = function (User) {
     };
 
     async function onSettingsLoaded(uid, settings) {
-        const data = await plugins.hooks.fire('filter:user.getSettings', { uid: uid, settings: settings });
+        const data = await plugins.hooks.fire('filter:user.getSettings', { uid, settings });
         settings = data.settings;
 
         const defaultTopicsPerPage = meta.config.topicsPerPage;
@@ -117,7 +116,7 @@ module.exports = function (User) {
         }
         data.userLang = data.userLang || meta.config.defaultLang;
 
-        plugins.hooks.fire('action:user.saveSettings', { uid: uid, settings: data });
+        plugins.hooks.fire('action:user.saveSettings', { uid, settings: data });
 
         const settings = {
             showemail: data.showemail,
@@ -148,7 +147,7 @@ module.exports = function (User) {
                 settings[notificationType] = data[notificationType];
             }
         });
-        const result = await plugins.hooks.fire('filter:user.saveSettings', { uid: uid, settings: settings, data: data });
+        const result = await plugins.hooks.fire('filter:user.saveSettings', { uid, settings, data });
         await db.setObject(`user:${uid}:settings`, result.settings);
         await User.updateDigestSetting(uid, data.dailyDigestFreq);
         return await User.getSettings(uid);

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const fs = require('fs');
@@ -101,8 +100,8 @@ async function initializeNodeBB() {
     await plugins.init(app, middleware);
     await plugins.hooks.fire('static:assets.prepare', {});
     await plugins.hooks.fire('static:app.preload', {
-        app: app,
-        middleware: middleware,
+        app,
+        middleware,
     });
     await routes(app, middleware);
     await privileges.init();
@@ -207,7 +206,6 @@ function setupHelmet(app) {
 
     app.use(helmet(options));
 }
-
 
 function setupFavicon(app) {
     let faviconPath = meta.config['brand:favicon'] || 'favicon.ico';

--- a/src/widgets/admin.js
+++ b/src/widgets/admin.js
@@ -15,8 +15,8 @@ admin.get = async function () {
 
     return {
         templates: buildTemplatesFromAreas(areas),
-        areas: areas,
-        availableWidgets: availableWidgets,
+        areas,
+        availableWidgets,
     };
 };
 

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -61,11 +61,11 @@ async function renderWidget(widget, uid, options) {
     }
 
     const userLang = config.userLang || meta.config.defaultLang || 'en-GB';
-    const templateData = _.assign({ }, options.templateData, { config: config });
+    const templateData = _.assign({ }, options.templateData, { config });
     const data = await plugins.hooks.fire(`filter:widget.render:${widget.widget}`, {
-        uid: uid,
+        uid,
         area: options,
-        templateData: templateData,
+        templateData,
         data: widget.data,
         req: options.req,
         res: options.res,
@@ -196,7 +196,7 @@ widgets.reset = async function () {
 
     let saveDrafts = drafts || [];
     for (const area of areas) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         const areaData = await widgets.getArea(area.template, area.location);
         saveDrafts = saveDrafts.concat(areaData);
         area.widgets = [];
@@ -223,7 +223,7 @@ widgets.resetTemplate = async function (template) {
 
 widgets.resetTemplates = async function (templates) {
     for (const template of templates) {
-        /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-await-in-loop */
         await widgets.resetTemplate(template);
     }
 };


### PR DESCRIPTION
I installed the tool using: `npm install standard --save-dev`
Once installed, I added it to the dev dependencies, so that it can be easily available for other developers. 

I ran the tool using: `npx standard src` and saved the output test/standardjs/terminalOutputForSrc.txt as evidence for running it. 

I then used the --fix command through `npx standard src --fix` to apply the suggested changes to the src directory, and fixed the resulting linting issues through: `npm run lint -- --fix`.